### PR TITLE
Fixed all broken moveit repo links after the merge

### DIFF
--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -58,7 +58,9 @@
           <ul class="dropdown-menu">
             <li><a href="/about/">About</a></li>
             <li role='separator' class='divider'>
-            <li><a href="/about/moveit-status/">status</a></li>
+            <li><a href="/about/source_code.html">Source Code</a></li>
+            <li role='separator' class='divider'>
+            <li><a href="/about/moveit-status/">Status</a></li>
           </ul>
         </li>
 

--- a/about/index.markdown
+++ b/about/index.markdown
@@ -5,90 +5,57 @@ date: 2013-11-20 04:37:44+00:00
 layout: page
 slug: about
 title: About
-wordpress_id: 87
 ---
 
-### Contact
-
+## Contact
 
 For media or other general queries about MoveIt!, please contact _robot.moveit@gmail.com_
 
+## Citing MoveIt!
 
-### Citing MoveIt!
-
-
-We are working on a technical publication that will be a better resource to cite MoveIt! in the near future. In the meantime, please use the following citation for MoveIt!
-
-
+Please use the following citation for MoveIt!
 
 
   * Ioan A. Sucan and Sachin Chitta, "MoveIt!", [Online] Available: [http://moveit.ros.org](http://moveit.ros.org)
 
-
-### Website 
-The website is maintained by Sachin Chitta and Praveen Singh.
-
-### License
+## License
 
 
 MoveIt! is open source and released under the BSD License. Each individual file in the MoveIt! source code contains a copy of the license.
 
+## Maintainers
 
-### Source Code
+The MoveIt! project is currently maintained by the following contributors with commit-access:
 
+Name | Organization | GitHub ID | Project Specialities
+------------ |:------------- |-------------|-------------|
+Michael Ferguson | Fetch Robotics | [mikeferguson](https://github.com/mikeferguson) | Releasing and Regressions
+Dave Coleman | Correll Lab, CU Boulder | [davetcoleman](https://github.com/davetcoleman) | Reviewing PRs
+Robert Haschke | CITEC, Bielefeld University | [rhaschke](https://github.com/rhaschke) | Fixing Bugs, Reviewing PRs
+Michael Görner | University of Hamburg | [v4hn](https://github.com/v4hn) | Fixing Bugs, New Features
+Isaac IY Saito | Tokyo Open Source Robotics | [130s](https://github.com/130s) | Releasing and Continuous Integration
+Sachin Chitta | Kinema Systems | [sachinchitta](https://github.com/sachinchitta) | Original Founder & Author of MoveIt!
+Ioan Sucan | Google X | [isucan](https://github.com/isucan) | Original Founder & Author of MoveIt!
+Ian McMahon | Rethink Robotics | [IanTheEngineer](https://github.com/IanTheEngineer) | Releasing
+Gijs van der Hoorn | Delft Univ. of Tech / ROS-I | [gavanderhoorn](https://github.com/gavanderhoorn) | IKFast Plugin
+Jorge Nicho | SwRI / ROS-I | [jrgnicho](https://github.com/jrgnicho) | IKFast Plugin
+Christian Dornhege | University of Freiburg | [dornhege](https://github.com/dornhege) | PR2 Code Base
 
-MoveIt! code is hosted on github in the [ros-planning organization](http://github.com/ros-planning) in the following repos:
+## Maintainer Alumni
 
+We would like to acknowledge past maintainers of MoveIt!
 
+Name             | GitHub ID |
+------------     |:------------- |
+Dave Hershburger | hersh |
+Acorn Pooley | N/A |
 
-
-  * [moveit_core](https://github.com/ros-planning/moveit_core) - Core C++ libraries
-
-
-  * [moveit_ros](https://github.com/ros-planning/moveit_ros) - ROS components
-
-
-  * [moveit_msgs](https://github.com/ros-planning/moveit_msgs) - MoveIt! messages
-
-
-  * [moveit_setup_assistant](https://github.com/ros-planning/moveit_setup_assistant) - MoveIt! Setup Assistant
-
-
-  * [moveit_planners](https://github.com/ros-planning/moveit_planners) - MoveIt! Planning libraries
-
-
-  * [moveit_commander](https://github.com/ros-planning/moveit_commander) - MoveIt! Commander
-
-
-  * [moveit_pr2](https://github.com/ros-planning/moveit_pr2) - PR2 specific MoveIt! configuration and plugins
-
-
-  * [moveit_robots](https://github.com/ros-planning/moveit_robots) - Robot specific MoveIt! files
-
-
-  * [moveit_plugins](https://github.com/ros-planning/moveit_plugins) - MoveIt! plugins for common functionality
-
-
-  * [moveit_ikfast](https://github.com/ros-planning/moveit_ikfast) - MoveIt! IKFast interface
-
-
-  * [moveit_resources](https://github.com/ros-planning/moveit_resources) - MoveIt! resources for testing, etc.
-
-
-  * [moveit_docs](https://github.com/ros-planning/moveit_docs) - MoveIt! documentation
-
-
-
-
-
-### Acknowledgements
+## Acknowledgements
 
 
 MoveIt! was initially developed at Willow Garage and we thank Willow Garage for its support of the MoveIt! project. We would also like to thank SRI International for its continuing support of the MoveIt! project since October 2013.
 
 We gratefully acknowledges the contributions of the following people to MoveIt! and associated packages that MoveIt! uses (or has used at some point):
-
-
 
 
   * Lydia Kavraki, Mark Moll, and associated members of the Kavraki Lab (Rice University) for developing OMPL - a suite of randomized planners that MoveIt! uses extensively.
@@ -110,6 +77,9 @@ We gratefully acknowledges the contributions of the following people to MoveIt! 
 
 
   * Michael Ferguson for writing the simple controller manager plugin
+
+
+  * Sachin Chitta and Praveen Singh for creating the current website
 
 
 MoveIt! evolved from the Arm Navigation and Grasping Pipeline components of ROS and we gratefully acknowledge the seminal contributions of all developers and researchers to those packages, especially Edward Gil Jones, Matei Ciocarlie, Kaijen Hsiao, Adam Leeper, and Ken Anderson.

--- a/about/source_code.markdown
+++ b/about/source_code.markdown
@@ -1,0 +1,45 @@
+---
+author: admin
+comments: false
+date: 2013-11-20 04:37:44+00:00
+layout: page
+slug: packages
+title: Source Code
+---
+
+# Source Code
+
+MoveIt! code is hosted on github in the [ros-planning organization](http://github.com/ros-planning) in the following repos:
+
+  * [moveit](https://github.com/ros-planning/moveit) - Main repo of MoveIt!, contains the following packages:
+    * moveit_core - Core C++ libraries
+    * moveit_ros - Metapackage
+    * moveit_ros_benchmarks
+    * moveit_ros_benchmarks_gui
+    * moveit_ros_manipulation - High level pick and place pipeline
+    * moveit_ros_move_group - Central ROS node for MoveIt!
+    * moveit_ros_perception - Octomap and other perception plugins
+    * moveit_ros_planning - Core ROS components and IK solvers
+    * moveit_ros_planning_interface - Python and ROS interfaces
+    * moveit_ros_robot_interaction - Interative marker tools for Rviz
+    * moveit_ros_visualization - Rviz tools
+    * moveit_ros_warehouse - Database connection
+    * moveit_planners - Metapackage
+    * moveit_planners_ompl - Open Motion Planning Library plugin
+    * moveit_setup_assistant - GUI for quickly setting up MoveIt!
+    * moveit_plugins - interfaces to controllers and other common functionality
+    * moveit_ikfast - setup tools for creating a analyical IK solver via OpenRave
+    * moveit_commander - terminal-based control interface
+  * [moveit_msgs](https://github.com/ros-planning/moveit_msgs) - MoveIt! messages
+  * [moveit_pr2](https://github.com/ros-planning/moveit_pr2) - PR2 specific MoveIt! configuration and plugins
+  * [moveit_robots](https://github.com/ros-planning/moveit_robots) - Robot specific MoveIt! files
+  * [moveit_resources](https://github.com/ros-planning/moveit_resources) - large file assets such as testing robots
+  * [moveit_advanced](https://github.com/ros-planning/moveit_advanced) - Experimental advanced capabilities of MoveIt!
+  * [srdfdom](https://github.com/ros-planning/srdfdom) - Semantic Robot Description Format
+  * [warehouse_ros](https://github.com/ros-planning/warehouse_ros) - Abstract interface for persisting ROS message data
+
+# Code Health
+
+We use [Travis](https://travis-ci.org/ros-planning/) continous integration for testing pull requests and overall code health. Travis status badges should be visible on the README.md of every MoveIt! repository.
+
+To see an overview of the activity for MoveIt! check our [Open HUB Project Summary](https://www.openhub.net/p/moveit_).

--- a/documentation/contributing/code.markdown
+++ b/documentation/contributing/code.markdown
@@ -22,7 +22,7 @@ In addition MoveIt! has some extra style preferences:
  - Avoid C-style functions such as ``FLT_EPSILON`` - instead use ``std::numeric_limits<double>::epsilon()``
  - Boost is an encouraged library when functionality is not available in the standard library
  - Prefer full variable names over short acryonms - e.g. ``robot_state_`` over ``rs_``
- - Deprecate functions using [MOVEIT_DEPRECATED](https://github.com/ros-planning/moveit_core/blob/kinetic-devel/macros/include/moveit/macros/deprecation.h) in deprecation.h
+ - Deprecate functions using MOVEIT_DEPRECATED in [deprecation.h](https://github.com/ros-planning/moveit/blob/kinetic-devel/macros/moveit_core/include/moveit/macros/deprecation.h)
 
 ## ROS
 

--- a/documentation/contributing/index.markdown
+++ b/documentation/contributing/index.markdown
@@ -82,21 +82,3 @@ We recommend you open an issue first asking if the change is a good idea, before
 ### Unit/Integration Tests
 
 Unit tests and integration tests are **always** welcomed, please add them to your PRs.
-
-## Maintainers
-
-The MoveIt! project is currently maintained by the following contributors with commit-access:
-
-Name | Organization | GitHub ID | Project Specialities
------------- |:------------- |-------------|-------------|
-Michael Ferguson | Fetch Robotics | [mikeferguson](https://github.com/mikeferguson) | Releasing and Regressions
-Dave Coleman | Correll Lab, CU Boulder | [davetcoleman](https://github.com/davetcoleman) | Reviewing PRs
-Robert Haschke | CITEC, Bielefeld University | [rhaschke](https://github.com/rhaschke) | Fixing Bugs, Reviewing PRs
-Michael Görner | University of Hamburg | [v4hn](https://github.com/v4hn) | Fixing Bugs, New Features
-Isaac IY Saito | Tokyo Open Source Robotics | [130s](https://github.com/130s) | Releasing and Continuous Integration
-Sachin Chitta | Kinema Systems | [sachinchitta](https://github.com/sachinchitta) | Original Founder & Author of MoveIt!
-Ioan Sucan | Google X | [isucan](https://github.com/isucan) | Original Founder & Author of MoveIt!
-Ian McMahon | Rethink Robotics | [IanTheEngineer](https://github.com/IanTheEngineer) | Releasing
-Gijs van der Hoorn | Delft Univ. of Tech / ROS-I | [gavanderhoorn](https://github.com/gavanderhoorn) | IKFast Plugin
-Jorge Nicho | SwRI / ROS-I | [jrgnicho](https://github.com/jrgnicho) | IKFast Plugin
-Christian Dornhege | University of Freiburg | [dornhege](https://github.com/dornhege) | PR2 Code Base

--- a/support/index.markdown
+++ b/support/index.markdown
@@ -15,62 +15,28 @@ wordpress_id: 89
 
 ### Mailing List
 
-
-
-
-
-
   * [Join the MoveIt! users mailing list](https://groups.google.com/forum/#!forum/moveit-users/join) (moveit-users _at_ googlegroups _dot_ com)
-
 
   * Browse the [Mailing List Archive](https://groups.google.com/forum/#%21forum/moveit-users)
 
-
-
-
-
 ### MoveIt! issues
 
+Post issues to the corresponding github repo for MoveIt! - default to the main "moveit" repo when unsure:
 
-Post issues to the corresponding github packages for MoveIt!
-
-
-
-
-  * [moveit_core](https://github.com/ros-planning/moveit_core/issues) - Issues related to any of the packages in moveit_core, the C++ API.
-
-
-  * [moveit_ros](https://github.com/ros-planning/moveit_ros/issues) - Issues related to any of the packages in moveit_ros, the ROS API to MoveIt!, move_group.
-
-
-  * [moveit_planners](https://github.com/ros-planning/moveit_planners/issues) - Issues related to the planners associated with MoveIt!, in particular OMPL.
-
-
-  * [moveit_setup_assistant](https://github.com/ros-planning/moveit_setup_assistant/issues) - Issues related to the MoveIt! Setup Assistant.
-
-
-  * [moveit_plugins](https://github.com/ros-planning/moveit_plugins/issues) - Issues related to the generic plugins included with MoveIt! packages.
-
-
+  * [moveit](https://github.com/ros-planning/moveit/issues) - Most issues in MoveIt!
+  * [moveit_robots](https://github.com/ros-planning/moveit_robots/issues) - Issues related to a specific robot type's moveit configuration
   * [moveit_pr2](https://github.com/ros-planning/moveit_pr2/issues) - Issues related to the PR2 specific set of MoveIt! packages.
-
-
-
 
 ### Web documentation issues
 
+Post issues about the web documentation to the website github package.
 
-Post issues about the web documentation to the moveit_docs github package.
-
-
-
-
-  * [moveit_docs](https://github.com/ros-planning/moveit_docs/issues) - Issues related to the Wiki Documentation.
-
-
-
+  * [moveit.ros.org](https://github.com/ros-planning/moveit.ros.org/issues) - Issues related to the Documentation.
 
 ### Change Logs
 
-
 Change logs are available directly from the corresponding [ROS wiki page for MoveIt!](http://wiki.ros.org/moveit).
+
+### Developer Discussions
+
+For discussion of development, maintenance, testing, and releases see the [Discoure](http://discourse.ros.org/c/moveit-developers) category. This location is not for MoveIt! users questions or application to specific robots.


### PR DESCRIPTION
Added new About->Source Code page
Documented more information about packages and locations
Moved maintainer list to about page
Created a past mainainer attribution table
Improved info about filing issues
Added note about Discourse moveit developers channel