### PR TITLE
Remove special libfcl instructions for Kinetic since it was fixed

### DIFF
--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -28,6 +28,8 @@
             <li><a href="/install">Users: Binary</a></li>
             <li role='separator' class='divider'>
             <li><a href="/install/source_install.html">Developers: Source</a></li>
+            <li role='separator' class='divider'>
+            <li><a href="/install/docker">Docker</a></li>
           </ul>
         </li>
 

--- a/install/docker/index.markdown
+++ b/install/docker/index.markdown
@@ -1,0 +1,37 @@
+# Docker
+
+## Usage
+
+### New Users
+
+For a debian-installed image of MoveIt:
+
+    docker run -it moveit/moveit:moveit-kinetic-release
+
+### Developers
+
+For a built-by-source image of MoveIt:
+
+    docker run -it moveit/moveit:moveit-kinetic-source
+
+Any of the three current distros work: [indigo|jade|kinetic]
+
+## Build
+
+MoveIt!'s docker images are built automatically on dockerhub.com, but you can modify and build locally if desired with the following command:
+
+    cd kinetic/source
+    docker build -t moveit/moveit:moveit-kinetic-source .
+
+## Using GUI's with Docker
+
+For more details see the [ROS tutorial](http://wiki.ros.org/docker/Tutorials/GUI) on this.
+
+    # This is not the safest way however, as you then compromise the access control to X server on your host
+    xhost +local:root # for the lazy and reckless
+
+    docker run -it --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" moveit/moveit:moveit-kinetic-source
+    export containerId=$(docker ps -l -q)
+
+    # Close security hole:
+    xhost -local:root

--- a/install/source_install.markdown
+++ b/install/source_install.markdown
@@ -61,19 +61,11 @@ The Kinetic MoveIt! branch currently requires using the ROS ``shadow-fixed`` rep
     echo 'deb http://packages.ros.org/ros-shadow-fixed/ubuntu xenial main' | sudo tee --append /etc/apt/sources.list.d/ros-latest.list
     sudo apt-get update
 
-FCL is currently not properly released into Kinetic, instead use this temporary debian via a setup script:
-
-    wget https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/.travis.before_script
-    source .travis.before_script
-
 Pull down required repositories and build from within the ``/src`` directory of your catkin workspace:
 
     wstool init .
     wstool merge https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
     wstool update
-
-Note: you may need to remove the ``fcl`` dependency temporarily in ``moveit/moveit_core/package.xml`` before running ``rosdep install``:
-
     rosdep install --from-paths . --ignore-src --rosdistro kinetic
     cd ..
     catkin config --extend /opt/ros/kinetic --cmake-args -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Since https://github.com/ros-planning/moveit/pull/50 passed, this is no longer needed