### PR TITLE
Point moveit website to new tutorials location

### DIFF
--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -42,7 +42,7 @@
             <li role='separator' class='divider'>
             <li><a href="/documentation/concepts/">Concepts</a></li>
             <li role='separator' class='divider'>
-            <li><a href="/documentation/tutorials/">Tutorials</a></li>
+            <li><a href="http://docs.ros.org/indigo/api/moveit_tutorials/html/">Tutorials</a></li>
             <li role='separator' class='divider'>
             <li><a href="/documentation/faqs/">FAQS</a></li>
             <li role="separator" class="divider"></li>

--- a/documentation/contributing/index.markdown
+++ b/documentation/contributing/index.markdown
@@ -13,21 +13,11 @@ We want to encourage all MoveIt! users to contribute back to the open source pro
 
 ## Enhancing Documentation
 
-Documentation for the MoveIt! project can be found in two places: in [moveit_tutorials](https://github.com/ros-planning/moveit_tutorials) and on this website:
+Documentation for the MoveIt! project can be found in two places: in [moveit_tutorials](https://github.com/ros-planning/moveit_tutorials) and on this website. Github's popular ``README.md`` files should be mainly used to redirect users to the corresponding Sphinx files and website pages.
 
 ### Within moveit_tutorials as Sphinx files
 
 Tutorials are documented as [reStructredText](http://docutils.sourceforge.net/rst.html) files (similar to Markdown) in [moveit_tutorials](https://github.com/ros-planning/moveit_tutorials). These tutorials mostly use the PR2 as their example robot and include example source code you can run. To edit or add more tutorials, create Github pull requests to that repo and the maintainers will graciously approve your help after review.
-
-If you are interested in generating the html pages locally on your machine, install [rosdoc_lite](http://wiki.ros.org/rosdoc_lite) (``apt-get install ros-kinetic-rosdoc-lite``) and run in the root of the package:
-
-    rosdoc_lite .
-
-This will automatically pick up the rosdoc.yaml and write the documentation to ``doc/html``
-
-For deploying documentation changes to the web, [Section 3 of rosdoc_lite wiki](http://wiki.ros.org/rosdoc_lite) says that "rosdoc_lite is automatically run for packages in repositories that have rosinstall files listed in the rosdistro repository." This is done about once every 24 hours, [overnight](http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation).
-
-Note that ``README.md`` files that are popular on Github should be mainly used to redirect users to the corresponding Sphinx files and website pages.
 
 ### moveit.ros.org
 

--- a/documentation/contributing/index.markdown
+++ b/documentation/contributing/index.markdown
@@ -13,19 +13,17 @@ We want to encourage all MoveIt! users to contribute back to the open source pro
 
 ## Enhancing Documentation
 
-Documentation for the MoveIt! project can be found in two places: within the source repositories and on the main website:
+Documentation for the MoveIt! project can be found in two places: in [moveit_tutorials](https://github.com/ros-planning/moveit_tutorials) and on this website:
 
-### Within the source repositories as Sphinx files
+### Within moveit_tutorials as Sphinx files
 
-Tutorials and other concepts are documented as [reStructredText](http://docutils.sourceforge.net/rst.html) files (similar to Markdown) in ``doc`` folders in various MoveIt! packages. For example, many of the beginner tutorials use the PR2 robot as an example, and their documentation pages can be found [here](https://github.com/ros-planning/moveit_pr2/tree/indigo-devel/pr2_moveit_tutorials/planning/src/doc)
-
-To edit or add more tutorials, create Github pull requests to the appropriate location and the maintainers will graciously approve your help after review.
+Tutorials are documented as [reStructredText](http://docutils.sourceforge.net/rst.html) files (similar to Markdown) in [moveit_tutorials](https://github.com/ros-planning/moveit_tutorials). These tutorials mostly use the PR2 as their example robot and include example source code you can run. To edit or add more tutorials, create Github pull requests to that repo and the maintainers will graciously approve your help after review.
 
 If you are interested in generating the html pages locally on your machine, install [rosdoc_lite](http://wiki.ros.org/rosdoc_lite) (``apt-get install ros-kinetic-rosdoc-lite``) and run in the root of the package:
 
     rosdoc_lite .
 
-i.e. [pr2_moveit_tutorials](https://github.com/ros-planning/moveit_pr2/tree/indigo-devel/pr2_moveit_tutorials). This will automatically pick up the rosdoc.yaml and write the documentation to ``doc/html``
+This will automatically pick up the rosdoc.yaml and write the documentation to ``doc/html``
 
 For deploying documentation changes to the web, [Section 3 of rosdoc_lite wiki](http://wiki.ros.org/rosdoc_lite) says that "rosdoc_lite is automatically run for packages in repositories that have rosinstall files listed in the rosdistro repository." This is done about once every 24 hours, [overnight](http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation).
 

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -14,7 +14,7 @@ wordpress_id: 85
 In this section, we will run through some of the basic concepts underlying the MoveIt! system architecture, interfaces and usage.
 
 
-### [Tutorials](tutorials)
+### [Tutorials](http://docs.ros.org/indigo/api/moveit_tutorials/html/)
 
 
 A set of beginner and advanced tutorials will run you through the key concepts in developing and running MoveIt!

--- a/documentation/tutorials/index.markdown
+++ b/documentation/tutorials/index.markdown
@@ -3,50 +3,7 @@ author: admin
 comments: false
 date: 2013-12-08 02:13:26+00:00
 layout: page
-slug: tutorials
-title: Tutorials
-wordpress_id: 120
+title: Redirect Tutorials
 ---
 
-# Beginner's Tutorials
-
-
-These tutorials will run you through how to use MoveIt! with your robot. It is assumed that you have already configured MoveIt! for your robot - check the [list of robots running MoveIt!](/robots) to see whether MoveIt! is already available for your robot. (Otherwise, skip to the tutorial on Setting up MoveIt! for your robot).
-
-The primary user interface to MoveIt! is through the _move_group_interface_. You can use this interface both through C++ and Python. A GUI-based interface is available through the use of the MoveIt! Rviz Plugin. We will walk through each of these interfaces in detail.
-
-Tutorial | Level | Description
------------- |:------------- |-------------|
-[The move_group_interface (C++)](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/planning/src/doc/move_group_interface_tutorial.html) | User | This tutorial will explain how to use the C++ interface to the _move_group_ node in your code
-[The move_group_interface (Python)](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/planning/scripts/doc/move_group_python_interface_tutorial.html) |User|This tutorial will run you through using the python interface to the _move_group_ node for scripting advanced behaviors
-[The MoveIt! Rviz Plugin (Rviz)](http://docs.ros.org/indigo/api/moveit_ros_visualization/html/doc/tutorial.html) | User |This tutorial will run you through the process of moving your robot using the MoveIt! Rviz plugin.
-[Rviz Joystick Control (Rviz)](http://docs.ros.org/jade/api/moveit_ros_visualization/html/doc/joystick.html) | User |How to use a PS3 or Xbox controller to move end effectors in Rviz and plan to new poses
-
-# Advanced Tutorials
-
-
-This set of advanced tutorials is meant for developers who are using MoveIt!'s C++ API. Most users wanting to access MoveIt! in C++ or Python should use the _move_group_interface_ (above).
-
-Tutorial | Level | Description
------------- |------------- |-------------|
-[Kinematics - RobotState and RobotModel (C++)](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/kinematics/src/doc/kinematics_tutorial.html) | Advanced | This tutorial introduces the kinematics C++ API for forward and inverse kinematics, setting and getting joint values, dealing with joint limits and computing jacobians
-[Kinematics - Configuration](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/kinematics/src/doc/kinematics_configuration.html) | Advanced | This tutorial presents the configuration parameters for the Kinematics components in MoveIt!, including setting up position only IK.
-[Planning Scene (C++)](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/planning/src/doc/planning_scene_tutorial.html) | Advanced | This tutorial shows how to use the planning scene C++ API for collision checking, checking constraints or for specifying user constraints
-[Planning Scene (ROS)](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/planning/src/doc/planning_scene_ros_api_tutorial.html) | Advanced | This tutorial shows how to use the planning scene ROS API for adding objects into the world, removing objects form the world and attaching and detaching objects from the robot
-[Motion Planning (C++)](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/planning/src/doc/motion_planning_api_tutorial.html) | Advanced | This tutorial illustrates the basics of loading a motion planner (using the ROS pluginlib library), calling it and setting joint space goals, pose goals and kinematic constraints
-[Motion Planning Pipeline(C++)](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/planning/src/doc/planning_pipeline_tutorial.html) | Advanced | This tutorial illustrates the basics of loading a motion planning pipeline and the use of planning request adapters for pre-processing and post-processing
-[Open Motion Planning Library Integration (C++)](http://docs.ros.org/jade/api/moveit_planners_ompl/html/tutorial.html) | Advanced | Information on advanced configurations for using planners in OMPL
-
-# Integrating a new robot with MoveIt!
-
-
-First, check whether your robot has already been integrated with MoveIt! (see the list of [robots using MoveIt! here](/robots/)). Otherwise, follow the tutorials in this section to integrate your robot with MoveIt! (and share your results on the MoveIt! mailing list)
-
-Tutorial | Level | Description
------------- |------------- |-------------|
-[MoveIt! Setup Assistant](http://docs.ros.org/indigo/api/moveit_setup_assistant/html/doc/tutorial.html) |User|Configure MoveIt! for a new robot using the MoveIt! Setup Assistant and interact with a visualized model of the robot in Rviz
-[Control](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/planning/src/doc/controller_configuration.html)|User|Setup MoveIt! to talk to the existing controllers on your robot
-[Perception](http://docs.ros.org/indigo/api/pr2_moveit_tutorials/html/planning/src/doc/perception_configuration.html) | User | Setup perception with MoveIt! and the sensors on your robot
-[Rviz Integration](http://docs.ros.org/indigo/api/moveit_ros_visualization/html/doc/tutorial.html) | User |The Rviz Motion Planning Interface: Beginner's Tutorial
-[MoveIt! IKFast Tutorial](http://docs.ros.org/indigo/api/moveit_ikfast/html/doc/ikfast_tutorial.html) (Optional) | User | Creating and integrating an IKFast Kinematics Plugin with MoveIt!
-[MoveIt! TRAC-IK Plugin](https://bitbucket.org/traclabs/trac_ik/src/HEAD/trac_ik_kinematics_plugin/) (Optional) | User | Using TRAC-IK for improved MoveIt! Inverse Kinematics over the default KDL solver
+This page has moved to <a href="http://docs.ros.org/indigo/api/moveit_tutorials/html/">http://docs.ros.org/indigo/api/moveit_tutorials/html/</a>


### PR DESCRIPTION
This should be merged asap for WMD - updates where users find tutorials

The index for tutorials is now centrally located within the Sphinx files, and not on this website. Previously there were multiple indexes that caused a lot of duplication that was hard to keep in sync

This also updates the documentation for how to contribute to the tutorials

See https://github.com/ros-planning/moveit/issues/36#issuecomment-241596120 for more discussion