### PR TITLE
Change arrows to proper symbol to prevent syntax error

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,11 +21,11 @@
     <hr>
     <div class='row'>
       <div class='col-sm-4'>
-        <-- <a href="{{page.next.url}}">{{ page.next.title }}</a>
+        &larr; <a href="{{page.next.url}}">{{ page.next.title }}</a>
       </div>
       <div class='col-sm-4'></div>
       <div class='col-sm-4'>
-        <a href="{{page.previous.url}}">{{ page.previous.title }}</a> -->
+        <a href="{{page.previous.url}}">{{ page.previous.title }}</a> &rarr;
       </div>
     </div>
   </div>


### PR DESCRIPTION
I think these arrows are confusing HTML parsers - we're getting lots of errors for this <a></a> tag:
https://travis-ci.org/mintar/moveit.ros.org/builds/154972935