### PR TITLE
Make code samples fit better

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -52,3 +52,9 @@
      margin-top: 10px;
      background: lavender;
  }
+
+ /* Other small tweaks */
+
+ pre code {
+     font-size: 90%;
+ }


### PR DESCRIPTION
Currently on the [install](http://moveit.ros.org/install/source/) page the ``.rosinstall`` lines wrap. This shrinks the font size of the code blocks slightly so that it fits. A live example is here: http://moveit.picknik.io/install/source/