### PR TITLE
[install] Update indigo package name.

### DIFF
--- a/install/index.markdown
+++ b/install/index.markdown
@@ -34,7 +34,7 @@ Choose your ROS distribution below:
 
 Simply run:
 
-    sudo apt-get install ros-indigo-moveit-full
+    sudo apt-get install ros-indigo-moveit
 
 ### Optional: Install PR2 Ubuntu Packages for MoveIt!
 


### PR DESCRIPTION
- `ros-indigo-moveit-full` is no longer available.
- `ros-indigo-moveit` will become available upon the next public sync.

Originally raised in this question http://answers.ros.org/question/251168/unable-to-locate-package-ros-indigo-moveit-full/