### PR TITLE
Clarify "Contributing" and "Handling Contributions" pages

### DIFF
--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -81,7 +81,7 @@
           <ul class="dropdown-menu">
             <li><a href="/documentation/contributing/">Contributing</a></li>
             <li role='separator' class='divider'>
-            <li><a href="/documentation/contributing/pullrequests/">Handling Contributions</a></li>
+            <li><a href="/documentation/contributing/pullrequests/">Pull Requests</a></li>
             <li role='separator' class='divider'>
             <li><a href="/documentation/contributing/code/">Style Guidelines</a></li>
             <li role='separator' class='divider'>

--- a/documentation/contributing/pullrequests/index.markdown
+++ b/documentation/contributing/pullrequests/index.markdown
@@ -8,7 +8,7 @@ title: Pull Requests
 redirect_from: "/documentation/contributing/pullrequests.html"
 ---
 
-# Handling Contributions
+# Handling Pull Requests
 
 MoveIt is a huge project with multiple maintainers and many contributing users.
 Thus, sometimes it becomes quite hard to keep track of all open requests and their current state.


### PR DESCRIPTION
I didn't like the naming in the menu and wasn't sure which to choose when I wanted to reference our "pull request" policy. I think this is easier for users to understand @v4hn