### PR TITLE
Add Kinetic section to Code API page

### DIFF
--- a/code-api/index.markdown
+++ b/code-api/index.markdown
@@ -8,34 +8,35 @@ title: Code API
 wordpress_id: 619
 ---
 
-## ROS Jade Code API
+## ROS Kinetic Code API
 
 ### Move Group Interface
 
-  * [MoveGroup class](http://docs.ros.org/jade/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1MoveGroup.html) - the main C++ interface to the _move_group_node_
-  * [PlanningSceneInterface class](http://docs.ros.org/jade/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1PlanningSceneInterface.html) - a C++ interface to the planning scene
-  * [MoveIt! commander](http://docs.ros.org/jade/api/moveit_commander/html/index.html) - documentation for the MoveIt! commander.
+  * [MoveGroupInterface class](http://docs.ros.org/kinetic/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1MoveGroupInterface.html) - the main C++ interface to the _move_group_node_.
+    `MoveGroupInterface` is the successor to the `MoveGroup` class from previous releases, which is [now deprecated](https://github.com/ros-planning/moveit/issues/37).
+  * [PlanningSceneInterface class](http://docs.ros.org/kinetic/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1PlanningSceneInterface.html) - a C++ interface to the planning scene
+  * [MoveIt! commander](http://docs.ros.org/kinetic/api/moveit_commander/html/index.html) - documentation for the MoveIt! commander.
 
 ### MoveIt! ROS
 
 _This API is meant for advanced developers. Most users should use the Move Group interface (above)._
 
-  * [Planning](http://docs.ros.org/jade/api/moveit_ros_planning/html) - The planning components in MoveIt! ROS, especially the planning scene, kinematics and monitors
-  * [Move Group](http://docs.ros.org/jade/api/moveit_ros_move_group/html) - The _move_group_node_
-  * [Perception](http://docs.ros.org/jade/api/moveit_ros_perception/html) - The perception components in MoveIt! ROS
-  * [Robot Interaction](http://docs.ros.org/jade/api/moveit_ros_robot_interaction/html) - The Interactivity components in MoveIt! ROS
+  * [Planning](http://docs.ros.org/kinetic/api/moveit_ros_planning/html) - The planning components in MoveIt! ROS, especially the planning scene, kinematics and monitors
+  * [Move Group](http://docs.ros.org/kinetic/api/moveit_ros_move_group/html) - The _move_group_node_
+  * [Perception](http://docs.ros.org/kinetic/api/moveit_ros_perception/html) - The perception components in MoveIt! ROS
+  * [Robot Interaction](http://docs.ros.org/kinetic/api/moveit_ros_robot_interaction/html) - The Interactivity components in MoveIt! ROS
 
 ### MoveIt! Core
 
 _This API is meant for advanced developers. Most users should use the Move Group interface (above)._
 
-  * [Core](http://docs.ros.org/jade/api/moveit_core/html) - The core components in MoveIt! for kinematics, planning scene, constraints, motion planning, collision checking and plugin interfaces
+  * [Core](http://docs.ros.org/kinetic/api/moveit_core/html) - The core components in MoveIt! for kinematics, planning scene, constraints, motion planning, collision checking and plugin interfaces
 
 ### MoveIt! OMPL Interface
 
 _This API is meant for advanced developers. Most users should use the Move Group interface (above)._
 
-  * [OMPL Interface](http://docs.ros.org/jade/api/moveit_planners_ompl/html) - The set of classes that allow MoveIt! to talk with OMPL.
+  * [OMPL Interface](http://docs.ros.org/kinetic/api/moveit_planners_ompl/html) - The set of classes that allow MoveIt! to talk with OMPL.
 
 ***
 


### PR DESCRIPTION
This is really just a copy-paste of the `Jade` section with some link renaming. I also changed the primary reference to `MoveGroupInterface` and added a note about the `MoveGroup` deprecation. Let me know if more changes are needed. Thanks!