### PR TITLE
adding google analytics back into page

### DIFF
--- a/_includes/default.html
+++ b/_includes/default.html
@@ -51,4 +51,14 @@ ript>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"> </script>
     <script type="text/javascript" src="/bootstrap-3.3.5-dist/js/bootstrap.min.js" ></script>
 
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-108532843-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-108532843-1');
+    </script>
+    
   </head>


### PR DESCRIPTION
google analytics was left out from the wordpress transition in 2015. This pull request add the script back to the main page.