### PR TITLE
[blog] Melodic beta release.

### DIFF
--- a/_posts/2018-05-23-melodic-beta-release.markdown
+++ b/_posts/2018-05-23-melodic-beta-release.markdown
@@ -1,0 +1,22 @@
+---
+author: 130s
+comments: false
+date: 2018-05-23 00:00:00+00:00
+layout: post
+slug: firstmelodicrelease
+title: MoveIt! beta officially released into ROS Melodic
+media_type: image
+media_link: https://discourse.ros.org/t/ros-melodic-morenia-release/4871
+description: MoveIt! is now released into ROS Melodic LTS (Long Term Support)!
+categories:
+- MoveIt!
+- ROS
+---
+
+MoveIt! is now released into ROS [Melodic](http://wiki.ros.org/melodic) LTS (Long Term Support).
+
+While MoveIt! in Melodic is still beta, if you're running your robot packages with ROS Melodic, and/or if you want to try the newest MoveIt!, start at [moveit.ros.org/install](http://moveit.ros.org/install/)
+
+![1st Melodic release](http://wiki.ros.org/melodic?action=AttachFile&do=get&target=melodic.jpg)
+
+--Your friendly MoveIt! maintenance team.

--- a/about/index.markdown
+++ b/about/index.markdown
@@ -26,7 +26,7 @@ Name | Organization | GitHub ID
 Dave Coleman | PickNik Consulting | [davetcoleman](https://github.com/davetcoleman)
 Robert Haschke | CITEC, Bielefeld University | [rhaschke](https://github.com/rhaschke)
 Michael Görner | University of Hamburg | [v4hn](https://github.com/v4hn)
-Isaac IY Saito | PlusOne Robotics | [130s](https://github.com/130s)
+Isaac IY Saito | Plus One Robotics | [130s](https://github.com/130s)
 Michael Ferguson | Fetch Robotics | [mikeferguson](https://github.com/mikeferguson)
 Ian McMahon | Rethink Robotics | [IanTheEngineer](https://github.com/IanTheEngineer)
 Gijs van der Hoorn | Delft Univ. of Tech / ROS-I | [gavanderhoorn](https://github.com/gavanderhoorn)


### PR DESCRIPTION
Following [maintainers' mtg decision](https://discourse.ros.org/t/moveit-maintainer-meeting-recap-may-29th-2018/4934).