### PR TITLE
fix ampersand symbols in markdown: & -> &amp;

### DIFF
--- a/_posts/2016-10-11-community-meeting.markdown
+++ b/_posts/2016-10-11-community-meeting.markdown
@@ -20,7 +20,7 @@ Our second MoveIt! community meeting webcast will be on October 27th at 8am Paci
 - Updates from the Flexible Collision Checking Library (FCL) - Dr. Dinesh Manocha and Jia Pan
 - Delft's Winning Amazon Picking Challenge Entry - Mukunda Bharatheesha
 - MoveIt! @ Fetch Robotics - Michael Ferguson
-- Q&A with original MoveIt! Developer & Founder - Dr. Ioan Sucan
+- Q&amp;A with original MoveIt! Developer & Founder - Dr. Ioan Sucan
 
 Webcast connection details:
 

--- a/_posts/2016-11-1-moveit-community-meeting-report.markdown
+++ b/_posts/2016-11-1-moveit-community-meeting-report.markdown
@@ -20,7 +20,7 @@ Thank you for coming to the MoveIt! Community Meeting and thanks to the presente
 * Updates from the Flexible Collision Checking Library (FCL) - Dr. Dinesh Manocha
 * Delft’s Winning Amazon Picking Challenge Entry - Mukunda Bharatheesha
 * MoveIt! @ Fetch Robotics - Michael Ferguson
-* Q&A with original MoveIt! Developer & Founder - Dr. Ioan Sucan
+* Q&amp;A with original MoveIt! Developer & Founder - Dr. Ioan Sucan
 
 In case you missed it, the video is available below
 

--- a/_posts/2016-8-5-world-moveit-day.markdown
+++ b/_posts/2016-8-5-world-moveit-day.markdown
@@ -15,7 +15,7 @@ categories:
 
 ![World MoveIt! Day]({{ site.url }}/assets/images/world_moveit_day.png)
 
-Join us on August 23rd for an international hackathon to improve the MoveIt! code base, documentation, and community. Following the heels of the repo merge, we hope to fix all broken links in the documentation, close as many longstanding pull requests and issues as possible, and have some fun with a newly released integrated simulation of MoveIt! manipulation + Gazebo + Fetch for us to test. An hour long Q&A session is scheduled at 9am Pacific to allow the community to meet the people merging their pull requests.
+Join us on August 23rd for an international hackathon to improve the MoveIt! code base, documentation, and community. Following the heels of the repo merge, we hope to fix all broken links in the documentation, close as many longstanding pull requests and issues as possible, and have some fun with a newly released integrated simulation of MoveIt! manipulation + Gazebo + Fetch for us to test. An hour long Q&amp;A session is scheduled at 9am Pacific to allow the community to meet the people merging their pull requests.
 
 We will be having several event locations including:
 

--- a/_posts/2018-4-16-moveit-on-discourse.markdown
+++ b/_posts/2018-4-16-moveit-on-discourse.markdown
@@ -7,7 +7,7 @@ slug: moveit-on-discourse
 title: MoveIt! Migrating from Google Groups to ROS Discourse
 media_type: image
 media_link: http://moveit.ros.org/assets/images/discourse.png
-description: In recent years there has been a migration related to ROS discussions, Q&A, and collaboration to ROS Discourse. Inspired by ROS-Industrial's migration this month away from Google Groups, and we believe its time for MoveIt! to migrate as well.
+description: In recent years there has been a migration related to ROS discussions, Q&amp;A, and collaboration to ROS Discourse. Inspired by ROS-Industrial's migration this month away from Google Groups, and we believe its time for MoveIt! to migrate as well.
 categories:
 - MoveIt!
 - ROS
@@ -15,7 +15,7 @@ categories:
 
 <img src="{{ site.url }}/assets/images/discourse.png" width="500" style="margin:10px"/>
 
-In recent years there has been a migration related to ROS discussions, Q&A, and collaboration to [ROS Discourse](http://discourse.ros.org). Inspired by ROS-Industrial's migration this month away from Google Groups, and we believe its time for MoveIt! to migrate as well. Starting April 16, 2018 the moveit-users Google Group will be marked as read-only. The content that is currently within the Google Groups forum will be kept available for reference, and inquiries to moveit-users will be met with an automatic reply to direct inquiries to the MoveIt! Discourse category.
+In recent years there has been a migration related to ROS discussions, Q&amp;A, and collaboration to [ROS Discourse](http://discourse.ros.org). Inspired by ROS-Industrial's migration this month away from Google Groups, and we believe its time for MoveIt! to migrate as well. Starting April 16, 2018 the moveit-users Google Group will be marked as read-only. The content that is currently within the Google Groups forum will be kept available for reference, and inquiries to moveit-users will be met with an automatic reply to direct inquiries to the MoveIt! Discourse category.
 
 For users the move to the [MoveIt! Discourse category](https://discourse.ros.org/c/moveit) should be quite convenient and efficient. Accounts from GitHub, or Google, may be used, so no new accounts will be needed in those cases.
 

--- a/documentation/contributing/index.markdown
+++ b/documentation/contributing/index.markdown
@@ -39,7 +39,7 @@ Those who are willing to answer MoveIt!-related questions only can get notified 
 
  ![img](../../assets/answers.ros_config_receive-notification.png)
 
-As an aside, a lot of documentation exists as Q&As on there, and if you feel so compelled, help us move some of that documentation onto the website.
+As an aside, a lot of documentation exists as Q&amp;As on there, and if you feel so compelled, help us move some of that documentation onto the website.
 
 [MoveIt! mailing list](https://groups.google.com/forum/#!forum/moveit-users) should be used for announcement and discussion only.
 


### PR DESCRIPTION
@davetcoleman The errors you mentioned in https://github.com/ros-planning/moveit.ros.org/pull/166#issuecomment-393344361 were obviously related to a stricter checking of html rules. A short analysis showed that they were related to ampersand symbols (in Q&A strings) that actually need to be encoded as `&amp;`. I fixed them.
The two remaining issues of broken links I leave for your team. 