### PR TITLE
Add MIGRATION to blog update

### DIFF
--- a/_posts/2018-05-23-melodic-beta-release.markdown
+++ b/_posts/2018-05-23-melodic-beta-release.markdown
@@ -4,7 +4,7 @@ comments: false
 date: 2018-05-23 00:00:00+00:00
 layout: post
 slug: firstmelodicrelease
-title: MoveIt! beta officially released into ROS Melodic
+title: MoveIt! officially released into ROS Melodic
 media_type: image
 media_link: http://wiki.ros.org/melodic?action=AttachFile&do=get&target=melodic.jpg
 description: MoveIt! is now released into ROS Melodic LTS (Long Term Support)!
@@ -16,6 +16,8 @@ categories:
 MoveIt! is now released into ROS [Melodic](http://wiki.ros.org/melodic) LTS (Long Term Support).
 
 While MoveIt! in Melodic is still beta, if you're running your robot packages with ROS Melodic, and/or if you want to try the newest MoveIt!, start at [moveit.ros.org/install](http://moveit.ros.org/install/)
+
+See the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/melodic-devel/MIGRATION.md) for a list of breaking changes in this release.
 
 --Your friendly MoveIt! maintenance team.
 


### PR DESCRIPTION
I realized we should mention the migration notes

Also I didn't want to confuse people about a "MoveIt! Beta"