### PR TITLE
Simplify src folder usage for source build

### DIFF
--- a/install/source/index.markdown
+++ b/install/source/index.markdown
@@ -26,8 +26,8 @@ Source installation requires [wstool](http://wiki.ros.org/wstool), [catkin_tools
 
 Optionally create a new workspace, you can name it whatever:
 
-    mkdir -p ~/ws_moveit/src
-    cd ~/ws_moveit/src
+    mkdir ~/ws_moveit
+    cd ~/ws_moveit
 
 Follow the instructions below for either Indigo, Kinetic, or Lunar:
 
@@ -35,11 +35,10 @@ Follow the instructions below for either Indigo, Kinetic, or Lunar:
 
 Pull down required repositories and build from within the ``/src`` directory of your catkin workspace:
 
-    wstool init .
-    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/indigo-devel/moveit.rosinstall
-    wstool update
-    rosdep install -y --from-paths . --ignore-src --rosdistro indigo
-    cd ..
+    wstool init src
+    wstool merge -t src https://raw.githubusercontent.com/ros-planning/moveit/indigo-devel/moveit.rosinstall
+    wstool update -t src
+    rosdep install -y --from-paths src --ignore-src --rosdistro indigo
     catkin config --extend /opt/ros/indigo --cmake-args -DCMAKE_BUILD_TYPE=Release
     catkin build
 
@@ -49,11 +48,10 @@ See final section below **Source The Catkin Workspace**. Optionally for MongoDB,
 
 Pull down required repositories and build from within the ``/src`` directory of your catkin workspace:
 
-    wstool init .
-    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
-    wstool update
-    rosdep install -y --from-paths . --ignore-src --rosdistro kinetic
-    cd ..
+    wstool init src
+    wstool merge -t src https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
+    wstool update -t src
+    rosdep install -y --from-paths src --ignore-src --rosdistro kinetic
     catkin config --extend /opt/ros/kinetic --cmake-args -DCMAKE_BUILD_TYPE=Release
     catkin build
 
@@ -65,11 +63,10 @@ See final section below **Source The Catkin Workspace**. Optionally for MongoDB,
 
 Pull down required repositories and build from within the ``/src`` directory of your catkin workspace:
 
-    wstool init .
-    wstool merge https://raw.githubusercontent.com/ros-planning/moveit/melodic-devel/moveit.rosinstall
-    wstool update
-    rosdep install -y --from-paths . --ignore-src --rosdistro melodic
-    cd ..
+    wstool init src
+    wstool merge -t src https://raw.githubusercontent.com/ros-planning/moveit/melodic-devel/moveit.rosinstall
+    wstool update -t src
+    rosdep install -y --from-paths src --ignore-src --rosdistro melodic
     catkin config --extend /opt/ros/melodic --cmake-args -DCMAKE_BUILD_TYPE=Release
     catkin build
 


### PR DESCRIPTION
I was inspired by the instruction at https://google-cartographer-ros.readthedocs.io/en/latest/ 

This reduces install by one line of code ``cd ..`` and is a bit more elegant IMHO