### PR TITLE
Refactor about page and add core contributors policy

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -53,7 +53,7 @@
             <h4>ABOUT</h4>
             <ul>
               <li>
-                <a href="/about/">About MoveIt!</a>
+                <a href="/about/">People</a>
               </li>
               <li>
                 <a href="/documentation/faqs/">FAQ</a>

--- a/_includes/nav-bar-blog.html
+++ b/_includes/nav-bar-blog.html
@@ -55,7 +55,7 @@
               About
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-              <a class="dropdown-item" href="/about/">About MoveIt!</a>
+              <a class="dropdown-item" href="/about/">People</a>
               <a class="dropdown-item" href="/robots/">Robots</a>
               <a class="dropdown-item" href="/documentation/faqs/">FAQ</a>
               <a class="dropdown-item" href="/support/">Get Support</a>

--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -55,7 +55,7 @@
               About
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-              <a class="dropdown-item" href="/about/">About MoveIt!</a>
+              <a class="dropdown-item" href="/about/">People</a>
               <a class="dropdown-item" href="/robots/">Robots</a>
               <a class="dropdown-item" href="/documentation/faqs/">FAQ</a>
               <a class="dropdown-item" href="/support/">Get Support</a>

--- a/about/index.markdown
+++ b/about/index.markdown
@@ -40,7 +40,7 @@ Name | Organization | GitHub ID
 ------------ |:------------- |-------------|
 Bryce Willey | Realtime Robotics | [BryceStevenWilley](https://github.com/BryceStevenWilley)
 Felix von Drigalski | OMRON SINIC X Corporation | [felixvd](https://github.com/felixvd)
-Simon Schmeißer | Isys Vision | [simonschmeisser](https://github.com/simonschmeisser)
+Simon Schmeißer | isys vision | [simonschmeisser](https://github.com/simonschmeisser)
 Henning Kayser | PickNik Consulting | [henningkayser](https://github.com/henningkayser)
 William Baker | Houston Mechatronics | [willcbaker](https://github.com/willcbaker)
 

--- a/about/index.markdown
+++ b/about/index.markdown
@@ -7,9 +7,15 @@ slug: about
 title: About
 ---
 
+# People
+
+MoveIt! is an open source project that is the result of the combined efforts of a large international community and multiple organizations. Many people have played a key role in making MoveIt! what it is today and they are awknowledged below - thank you!
+
+The primary governance of MoveIt! takes place during monthly meetings of the maintainers and core contributors through general consensus. Organizational leadership and administration is lead by [PickNik Consulting](https://picknik.ai/).
+
 ## Maintainers
 
-The MoveIt! project is currently maintained by the following contributors with commit-access:
+MoveIt! maintainers, commonly referred to as "committers" in other open source projects, are the seasoned experts of the MoveIt! project and the only ones who can merge pull requests.
 
 Name | Organization | GitHub ID
 ------------ |:------------- |-------------|
@@ -18,13 +24,25 @@ Robert Haschke | CITEC, Bielefeld University | [rhaschke](https://github.com/rha
 Michael Görner | University of Hamburg | [v4hn](https://github.com/v4hn)
 Isaac IY Saito | Plus One Robotics | [130s](https://github.com/130s)
 Michael Ferguson | Fetch Robotics | [mikeferguson](https://github.com/mikeferguson)
-Ian McMahon | Rethink Robotics | [IanTheEngineer](https://github.com/IanTheEngineer)
+Ian McMahon | Toyota Research Institute | [IanTheEngineer](https://github.com/IanTheEngineer)
 Gijs van der Hoorn | Delft Univ. of Tech / ROS-I | [gavanderhoorn](https://github.com/gavanderhoorn)
 Jorge Nicho | SwRI / ROS-I | [jrgnicho](https://github.com/jrgnicho)
 Bence Magyar | Heriot-Watt University | [bmagyar](https://github.com/bmagyar)
 Mike Lautman | PickNik Consulting | [mlautman](https://github.com/mlautman)
 Jon Binney | Iron Ox | [jonbinney](https://github.com/jonbinney)
 Zak Kingston | Rice University | [zkingston](https://github.com/zkingston)
+
+## Core Contributors
+
+We have a stringent process for giving commit access to the code base to ensure quality, but we want to have as many people involved in reviewing pull requests and responding to issues. We have a non-commit access category of MoveIt! experts we call "Core Contributors" - these participants are recognized for their hard work and contributions to MoveIt! early on. See the [full maintainer policy](maintainer_policy).
+
+Name | Organization | GitHub ID
+------------ |:------------- |-------------|
+Bryce Willey | Realtime Robotics | [BryceStevenWilley](https://github.com/BryceStevenWilley)
+Felix von Drigalski | OMRON SINIC X Corporation | [felixvd](https://github.com/felixvd)
+Simon Schmeißer | Isys Vision | [simonschmeisser](https://github.com/simonschmeisser)
+Henning Kayser | PickNik Consulting | [henningkayser](https://github.com/henningkayser)
+William Baker | Houston Mechatronics | [willcbaker](https://github.com/willcbaker)
 
 ## Maintainer Alumni
 
@@ -36,11 +54,6 @@ Sachin Chitta | Kinema Systems | [sachinchitta](https://github.com/sachinchitta)
 Ioan Sucan | Google X | [isucan](https://github.com/isucan)
 Dave Hershburger | Kinema Systems | [hersh](https://github.com/hersh) |
 Acorn Pooley | SRI International | N/A |
-Maarten de Vries | Delft Robotics | [de-vri-es](https://github.com/de-vri-es)
-
-## License
-
-MoveIt! is open source and released under the [BSD License v3](https://opensource.org/licenses/BSD-3-Clause). Each individual file in the MoveIt! source code should contain a copy of the license.
 
 ## Citing MoveIt!
 
@@ -60,9 +73,9 @@ Franka Emika sponsored a codesprint in 2018 to improve MoveIt!'s tutorials, docu
 
 ## History and Acknowledgements
 
-MoveIt!'s first [commit](https://github.com/ros-planning/moveit/commit/206e93c555a6ddcdbe826809c30b90b89bbb52d8) was October 2011. MoveIt! was initially developed at Willow Garage by Sachin Chitta, Ioan Sucan, Gil E. Jones, Acorn Pooley, Suat Gedikli and Dave Hershberger and we thank Willow Garage for its support of the MoveIt! project. We would also like to thank SRI International for its support of the MoveIt! project between October 2013 and June 2015.
+MoveIt!'s first [commit](https://github.com/ros-planning/moveit/commit/206e93c555a6ddcdbe826809c30b90b89bbb52d8) was October 2011. MoveIt! was initially developed at Willow Garage by Sachin Chitta, Ioan Sucan, Gil E. Jones, Acorn Pooley, Suat Gedikli, and Dave Hershberger and we thank Willow Garage for its support of the MoveIt! project. We would also like to thank SRI International for its support of the MoveIt! project between October 2013 and June 2015. Since then, PickNik has been leading the support of the MoveIt! project.
 
-We gratefully acknowledges the contributions of the following people to MoveIt! and associated packages that MoveIt! uses (or has used at some point):
+We gratefully acknowledge the early contributions of the following people to MoveIt! and associated packages that MoveIt! uses:
 
   * Lydia Kavraki, Mark Moll, and associated members of the Kavraki Lab (Rice University) for developing OMPL - a suite of randomized planners that MoveIt! uses extensively.
 
@@ -72,20 +85,18 @@ We gratefully acknowledges the contributions of the following people to MoveIt! 
 
   * Armin Hornung, Kai Wurm, Maren Bennewitz, Cyril Stachniss, and Wolfram Burgard for developing Octomap - software for 3D occupancy mapping used by MoveIt!
 
-  * Mrinal Kalakrishnan, Peter Pastor and Stefan Schaal at USC for developing STOMP, the distance field components in MoveIt! and the implementation of the CHOMP algorithm in Arm Navigation
+  * Mrinal Kalakrishnan, Peter Pastor and Stefan Schaal at USC for developing STOMP and CHOMP
 
-  * Dave Coleman from the University of Colorado, Boulder for developing the MoveIt! Setup Assistant and adding documentation to the MoveIt! website.
+  * Dave Coleman for developing the MoveIt! Setup Assistant, OMPL algorithms, and taking leadership of the MoveIt! project since 2016.
 
-  * Michael Ferguson for writing the simple controller manager plugin
+  * Michael Ferguson for the simple controller manager plugin, inspiring World MoveIt! Day, and helping revamp the MoveIt! project in 2016.
 
-  * Sachin Chitta and Praveen Singh for creating the current website
+  * Edward Gil Jones, Matei Ciocarlie, Kaijen Hsiao, Adam Leeper, and Ken Anderson for their seminal contributions of Arm Navigation and Grasping Pipeline components that MoveIt! evolved from.
 
-MoveIt! evolved from the Arm Navigation and Grasping Pipeline components of ROS and we gratefully acknowledge the seminal contributions of all developers and researchers to those packages, especially Edward Gil Jones, Matei Ciocarlie, Kaijen Hsiao, Adam Leeper, and Ken Anderson.
+  * Contributions of Willow Garage interns who have worked on MoveIt!, Arm Navigation, and associated components
 
-We also acknowledge the contributions of the Willow Garage interns who have worked on MoveIt!, Arm Navigation and associated components, members of the ROS and PR2 communities who have used, provided feedback and provided contributions to MoveIt! and Arm Navigation and members of the ROS community for developing the infrastructure that MoveIt! builds on.
+  * Members of the ROS and PR2 communities who have used, provided feedback and provided contributions to MoveIt!
 
-We also acknowledge the contributions of the ROS-Industrial consortium led by the Southwest Research Institute for supporting and building up infrastructure for applying MoveIt! and Arm Navigation to industrial robots and environments. Similarly, we acknowledge the contributions of Fraunhofer IPA to MoveIt! and support for the ROS-Industrial effort in Europe.
+  * ROS-Industrial consortium led by the Southwest Research Institute and Fraunhofer IPA for applying MoveIt! to industrial robots.
 
-## Press Kit
-
-See [Logo Guidelines](/about/press_kit)
+  * Open Robotics for playing an advisory role, maintaining ROS, and providing the infrastructure for releasing packages

--- a/about/maintainer_policy/index.markdown
+++ b/about/maintainer_policy/index.markdown
@@ -1,0 +1,41 @@
+---
+author: admin
+comments: false
+date: 2019-16-01 04:37:44+00:00
+layout: page
+slug: maintainer_policy
+title: Maintainer Policy and Core Contributors Governing Guidelines
+---
+
+MoveIt! core contributors and maintainers are the driving force of keeping MoveIt! alive by responding to pull requests, issues, and user questions. These two groups of highly involved participants also help fix critical regressions and support developing future versions of MoveIt!. We greatly appreciate all of the core contributors and maintainers of the MoveIt! project and thank you for your support. In addition to gratitude, some advantages of being a MoveIt! maintainer / core contributor:
+
+ - Build up expertise of one of the most popular ROS libraries
+ - Improve your resume / CV
+ - Be listed on the MoveIt! website
+ - Networking opportunities: gain reputation in the largest robotics community on earth
+ - Quicker code contributions: you only need one review to get your code merged in, while non-maintainer/non-core contributor pull requests require two approvals.
+
+## Core Contributors
+
+We have a stringent process for giving commit access to the code base, but we want to have as many people involved in reviewing pull requests and responding to issues. We have a non-commit access category of MoveIt! experts we call "Core Contributors" - these participants are recognized for their hard work and contributions to MoveIt! early on. Eventually after fully proving their expertise, full maintainer/commiter status can be granted.
+
+To be considered a "Core Contributor", we look for demonstrated excitement about the MoveIt! project. We also ask you have completed at minimum the following:
+
+ - 2 substantial pull requests merged
+ - 4 pull requests reviewed via the "Approve" or "Request Changes" button
+ - 1 maintainer meeting attended
+
+## Maintainers
+
+MoveIt! maintainers, commonly referred to as "committers" in other open source projects, are the seasoned experts of the MoveIt! project. Becoming a maintainer is generally an invite-only process and ideally achieved by first becoming a core contributor.
+
+### Responsibilities
+
+Joining the Maintainer team means you have the responsibility of commit access to our Github repositories. You then can merge other's code contributions, but you should never merge your own code without someone else's review.
+
+We've formalized the process here to disambiguate when someone should be added. We hope it's not too intimidating as we want to add as many qualified maintainers as possible:
+
+ - Have proven a good understanding of fundamental parts of the MoveIt! code base
+ - Have completed at least the minimum requirements for core contributors, above
+ - Be willing to help review on average 1 pull request a week or more
+ - Read the MoveIt! pull request guidelines to understand our policies

--- a/documentation/contributing/index.markdown
+++ b/documentation/contributing/index.markdown
@@ -13,6 +13,10 @@ First off, thank you for considering contributing to MoveIt! - it's people like 
 
 Following these guidelines helps to communicate that you respect the time of the developers managing and developing this open source project. In return, we should reciprocate that respect in addressing your issue, assessing changes, and helping you finalize your pull requests.
 
+## Press Kit
+
+See [Logo Guidelines](/about/press_kit)
+
 ## Enhancing Documentation
 
 Documentation for the MoveIt! project can be found in two places: in [moveit_tutorials](https://github.com/ros-planning/moveit_tutorials) and on this website. Github's popular ``README.md`` files should be mainly used to redirect users to the corresponding tutorial and website pages.

--- a/documentation/faqs/index.markdown
+++ b/documentation/faqs/index.markdown
@@ -27,7 +27,7 @@ _What is the difference between MoveIt! and OMPL?_
 
 _What kind of open source license does MoveIt! use?_
 
- * MoveIt! is released under the buisness-friendly [BSD License v3](https://opensource.org/licenses/BSD-3-Clause). Each individual file in the MoveIt! source code should contain a copy of the license.
+ * MoveIt! is released under the business-friendly [BSD License v3](https://opensource.org/licenses/BSD-3-Clause). Each individual file in the MoveIt! source code should contain a copy of the license.
 
 ## Bugs/Issues
 

--- a/documentation/faqs/index.markdown
+++ b/documentation/faqs/index.markdown
@@ -16,10 +16,6 @@ _What is the difference between MoveIt! and ROS?_
   * MoveIt! runs on top of ROS (Robot Operating System).
   * ROS is an open-source meta-operating system for robots that provides low-level functionality like a build system, message passing, device drivers and some integrated capabilities like navigation. MoveIt! provides functionality for kinematics, motion/path planning, collision checking, 3D perception, robot interaction and much, much more. MoveIt! is a primary source of a lot of the functionality for manipulation (and mobile manipulation) in ROS. MoveIt! builds on the ROS messaging and build systems and utilizes some of the common tools in ROS like the ROS Visualizer (Rviz) and the ROS robot format (URDF). MoveIt! is fast becoming the entry point into ROS, especially through the use of the MoveIt! Setup Assistant for configuring new robots.
 
-_What is the difference between MoveIt! and Arm Navigation?_
-
-  * Arm Navigation was the predecessor to MoveIt!. MoveIt! is significantly different to Arm Navigation in system architecture and implementation, especially in terms of performance and extensibility. MoveIt! moved away from the process based architecture that Arm Navigation used, mainly to lower the cost of maintaining a representation of the world in multiple nodes. MoveIt! also takes advantage of the parallelization provided by collision checkers like FCL.
-
 _What is the difference between MoveIt! and ROS-Industrial?_
 
   * The ROS-Industrial consortium aims to use the advanced tools in MoveIt! and ROS to build and demonstrate advanced applications in industry. They were inspired by the success of Arm Navigation (MoveIt!'s predecessor) on the PR2 robot.
@@ -28,6 +24,10 @@ _What is the difference between MoveIt! and ROS-Industrial?_
 _What is the difference between MoveIt! and OMPL?_
 
   * [OMPL](http://ompl.kavrakilab.org) is an open-source motion planning library that is used by MoveIt! for motion planning. MoveIt! uses an extensible plugin architecture and other motion planning libraries can also easily be integrated with MoveIt!. OMPL provides a variety of high-quality well-tested randomized planners.
+
+_What kind of open source license does MoveIt! use?_
+
+ * MoveIt! is released under the buisness-friendly [BSD License v3](https://opensource.org/licenses/BSD-3-Clause). Each individual file in the MoveIt! source code should contain a copy of the license.
 
 ## Bugs/Issues
 

--- a/documentation/source-code-api/index.markdown
+++ b/documentation/source-code-api/index.markdown
@@ -61,8 +61,6 @@ In addition, the following repos exist for testing:
 
 We use [Travis](https://travis-ci.org/ros-planning/) continous integration combined with the [moveit_ci](https://github.com/ros-planning/moveit_ci) for testing pull requests and overall code health. Travis status badges should be visible on the README.md of every MoveIt! repository.
 
-To see an overview of the activity for MoveIt! check our [Open HUB Project Summary](https://www.openhub.net/p/moveit).
-
 ## ROS Melodic Code API
 
 ### Move Group Interface

--- a/documentation/source-code-api/index.markdown
+++ b/documentation/source-code-api/index.markdown
@@ -7,6 +7,10 @@ slug: packages
 title: Source Code & API
 ---
 
+## License
+
+MoveIt! is open source and released under the [BSD License v3](https://opensource.org/licenses/BSD-3-Clause). Each individual file in the MoveIt! source code should contain a copy of the license.
+
 # Source Code
 
 MoveIt! code is hosted on github in the [ros-planning organization](http://github.com/ros-planning) in the following repos:

--- a/documentation/source-code-api/index.markdown
+++ b/documentation/source-code-api/index.markdown
@@ -61,6 +61,8 @@ In addition, the following repos exist for testing:
 
 We use [Travis](https://travis-ci.org/ros-planning/) continous integration combined with the [moveit_ci](https://github.com/ros-planning/moveit_ci) for testing pull requests and overall code health. Travis status badges should be visible on the README.md of every MoveIt! repository.
 
+To see an overview of the activity for MoveIt! check our [Open HUB Project Summary](https://www.openhub.net/p/moveit).
+
 ## ROS Melodic Code API
 
 ### Move Group Interface


### PR DESCRIPTION
- Provide better intro and governance details
- Cleanup acknowledgements section
- Rename "About" page to "People" because this is more human-friendly and funny to see next to "Robots" in the menu
- Move the press kit and license info to other locations on the website

I've also added the following initial core contributors after exhaustively reviewing everyone's merged pull request count and number of reviews they have done:

@felixvd
@BryceStevenWilley
@simonschmeisser
@henningkayser
@willcbaker

I believe I have talked to all of them in the past about being potential maintainers and this is now the first step in that process. Let me know if you are not interested in being listed on the website as this. 