### PR TITLE
Update docker instructions to nvidia-docker2

### DIFF
--- a/install/docker/index.markdown
+++ b/install/docker/index.markdown
@@ -1,5 +1,5 @@
 ---
-author: davetcoleman
+author: davetcoleman, felixvd
 comments: false
 date: 2016-8-5 20:43:44+00:00
 layout: page
@@ -11,53 +11,84 @@ title: Docker Install
 
 Docker is an open-source project that automates the deployment of Linux applications inside software containers. See [https://www.docker.com/](https://www.docker.com/).
 
-Docker can help you easily evaluate someone else's code changes without breaking your local setup, as well as test on versions of Linux other than your local installed version. MoveIt has an [official MoveIt Docker build](https://hub.docker.com/r/moveit/moveit/) that lets you quickly get a MoveIt setup in a local container.
+Docker can help you easily evaluate someone else's code changes without changing your local setup, as well as test on versions of Linux other than your locally installed version. MoveIt has an [official MoveIt Docker build](https://hub.docker.com/r/moveit/moveit/) that lets you quickly run MoveIt in a local container.
 
 ## Installing Docker
 
-Before starting this tutorial please complete installation as described in [Docker's installation instructions](https://docs.docker.com/engine/installation/). Installation instructions are available for multiple operating systems.
+Before starting this tutorial, please complete the installation as described in [Docker's installation instructions](https://docs.docker.com/install/). Installation instructions are available for multiple operating systems.
 
 Note that for recent Linux distros, the installation is basically just a single wget command. You may also want [add your user to the docker group](https://docs.docker.com/engine/installation/linux/ubuntulinux/#/create-a-docker-group) to avoid having to use sudo permissions when you use the docker command.
 
 ### Ubuntu
 
-If you are running a recent version of Ubuntu (e.g. 14.04, 16.04) it can be as simple as:
+If you are running a recent version of Ubuntu (e.g. 16.04, 18.04) it can be as simple as:
 
     sudo apt-get install curl
     curl -sSL https://get.docker.com/ | sh
     sudo usermod -aG docker $(whoami)
 
-And you will likely need to log out and back into your user account for the changes to take affect.
+And you will likely need to log out and back into your user account for the changes to take effect.
 
 ## Running MoveIt Containers
 
-To run a Debian-installed container of MoveIt with graphics support:
+To use Rviz (and other GUIs), you need to first set up hardware acceleration for Docker as described [here](http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration#nvidia-docker2) and install nvidia-docker2 according to [these instructions](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)).
 
-    wget https://raw.githubusercontent.com/ros-planning/moveit/master/.docker/gui-docker -O gui-docker && chmod +x gui-docker
-    ./gui-docker -it --rm moveit/moveit:melodic-release /bin/bash
+Then, use the command below to execute the script in to create and run a persistent container:
 
-This will attempt to use nvidia-docker if hardware and drivers are available.
+    ./gui-docker
 
-**Command-Line Only**
+You can test that the GUI works by running rviz:
 
-    docker run -it moveit/moveit:melodic-release
+    roscore > /dev/null & rosrun rviz rviz
+
+The container is persistent, so changes you make inside your container will remain. Running `gui-docker` in multiple terminals will connect them to the same container. To reset the container, simply delete it using the commands below. It will be recreated next time you run `gui-docker`:
+
+    docker stop default_moveit_container && docker rm default_moveit_container
+
+If you want to use the command line only (without GUI interfaces like Rviz) in a non-persistent container, simply run this command:
+
+    docker run -it moveit/moveit:master-source bash
 
 ## MoveIt Container Types
 
 There are many variants of the MoveIt Docker available as documented [here](http://moveit.ros.org/documentation/contributing/continuous_integration/). For example, any of the two current distros work: [kinetic, melodic]. Other variations include:
 
-- **moveit/moveit:melodic-source** contains a full MoveIt workspace downloaded and built to ~/ws_moveit/src. This container is useful for developers wanting to test or develop in a sandbox.
+- **moveit/moveit:master-source** contains a full MoveIt workspace downloaded and built to ~/ws_moveit/src. This container is useful for developers wanting to test or develop in a sandbox.
 - **moveit/moveit:melodic-release** builds ontop of the CI image, the full debian-based install of MoveIt using apt-get.
-- **moveit/moveit:melodic-ci** an image optimized for running continuous integration with Travis
-- **moveit/moveit:melodic-ci-shadow** an image optimized for running continuous integration with Travis using the latest unreleased build of ROS
+- **moveit/moveit:master-ci** an image optimized for running continuous integration with Travis
+- **moveit/moveit:master-ci-shadow** an image optimized for running continuous integration with Travis using the latest unreleased build of ROS
 
-## Advanced
+## Troubleshooting
 
-To make the source container more useful for developing and testing code, we recommend you install the following extra dependencies because the docker container is very bare-bones:
+- `Error response from daemon: OCI runtime create failed...`
+
+Your container may have an issue. Try deleting it by `docker stop default_container && docker rm default_container` and running `gui-docker` again. 
+
+## Advanced features
+
+### Linking local folders
+You can link a folder on your hard disk to the Docker container, so you can edit them with your favorite tools on the host, with the `volume` option, e.g.:
+
+    -v ~/moveit_ws:/root/linked_ws_moveit
+
+Use this option when you first create the container (or after deleting it with `docker rm my-moveit-container`), like this:
+
+    ./gui-docker -c my-moveit-container -v ~/moveit_ws:/root/linked_moveit_ws
+
+After the container is created it will stay linked, so you can simply enter it on subsequent calls:
+
+    ./gui-docker -c my-moveit-container
+
+Files created inside the Docker container are owned by root. Use `chown . -R 1000:1000` inside the container to assign files to the host user if you run into access issues.
+
+### Convenience 
+The Docker container does not contain development and testing tools. You can install some in the container:
 
     apt-get install less ssh bash-completion tree nano
+
+### Modify and build images locally
 
 MoveIt's docker containers are built automatically on dockerhub.com, but you can modify and build locally if desired with the following command:
 
     cd moveit/.docker/source
-    docker build -t moveit/moveit:melodic-source .
+    docker build -t moveit/moveit:master-source .

--- a/install/docker/index.markdown
+++ b/install/docker/index.markdown
@@ -36,7 +36,7 @@ To use Rviz (and other GUIs), you probably want to set up hardware acceleration 
 Then, the wrapper script `gui-docker` can be used to correctly setup the docker environment for graphics support.
 For example, you can run the MoveIt docker container using the following command:
 
-    ./gui-docker -it --rm moveit/moveit:melodic-release /bin/bash
+    ./gui-docker -it --rm moveit/moveit:melodic-source /bin/bash
 
 You can test that the GUI works by running rviz:
 
@@ -44,15 +44,15 @@ You can test that the GUI works by running rviz:
 
 If you specify a container name (via `-c <name>`), you can also continue or re-enter a previously started container:
 
-    ./gui-docker -c my_container -it moveit/moveit:melodic-release /bin/bash
+    ./gui-docker -c my_moveit_container -it moveit/moveit:melodic-source /bin/bash
 
 As the previous command dropped the `--rm` option, the container will be persistent, so changes you make inside the container will remain.
 Running `gui-docker` in multiple terminals will connect them all to the same container.
-For convienency, the script defines sensible defaults. So, just running
+For convienence, the script defines sensible defaults. So, just running
 
     ./gui-docker
 
-will run an interactive bash inside the `melodic-release` container and make it persistent with the name `default_moveit_container`.
+will run an interactive bash inside the `melodic-source` container and make it persistent with the name `default_moveit_container`.
 To stop and remove the container, just issue the following commands:
 
     docker stop default_moveit_container && docker rm default_moveit_container
@@ -83,15 +83,15 @@ You can link a folder on your hard disk to the Docker container, so you can edit
 
     -v ~/moveit_ws:/root/linked_ws_moveit
 
-Use this option when you first create the container (or after deleting it with `docker rm my-moveit-container`), like this:
+Use this option when you first create the container (or after deleting it with `docker rm my_moveit_container`), like this:
 
-    ./gui-docker -c my_container -v ~/moveit_ws:/root/linked_moveit_ws
+    ./gui-docker -c my_moveit_container -v ~/moveit_ws:/root/linked_moveit_ws
 
 After the container is created, the folder will stay linked. So you can simply enter it on subsequent calls like this:
 
-    ./gui-docker -c my_container
+    ./gui-docker -c my_moveit_container
 
-Files created inside the Docker container are usually owned by root. Check and fix permissions, if you run into issues.
+Files created inside the Docker container are usually owned by root. Check and fix permissions, if you run into issues. You can execute `chown . -R 1000:1000` in the container to assign files to the host user, by replacing `1000` with your host user ID (which you can obtain with `id -u` on an Ubuntu host).
 
 ### Convenience
 The Docker container does not contain development and testing tools. You might want to install some in the container:


### PR DESCRIPTION
### Description

Fixes https://github.com/ros-planning/moveit/issues/1368.

Our nvidia-docker instructions were outdated. This is just a rough draft that copies the instructions from the ROS.org wiki.

The previous version was more elegant, but I haven't found a way to do this without building a local image to set the environment variables. I think making the `Dockerfile` and `run-gui-moveit-docker` downloadable like `gui-docker` would be good, but I didn't want to open two PRs at once.

@davetcoleman is listed as the author of the file so he will have to comment. 

This script is more self-contained than `gui-docker`, but I think I prefer it without the additional arguments. Fewer things to remember when spinning up a test environment, and users who need to change something are also comfortable making changes to the script.

### Checklist
- [ ] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
