### PR TITLE
making note of ccache install issue

### DIFF
--- a/install/source/index.markdown
+++ b/install/source/index.markdown
@@ -160,6 +160,13 @@ Refer to the [ccache website](https://ccache.dev) for more information on contro
 
     catkin build
 
+**NOTE**: If `catkin build` fails with a mesage similar to ``ccache: error: Failed to create directory $HOME/.ccache/tmp: Permission denied`` then you can fix it with the following commands: ::
+
+    USERNAME=`whoami` && \
+    USERGROUP=`id -gn` && \
+    sudo chown $USERNAME ~/.ccache/ && \
+    sudo chgrp $USERGROUP ~/.ccache/
+
 ### Source the Catkin Workspace
 
 Setup your environment - you can do this every time you work with this particular source install of the code, or you can add this to your ``.bashrc`` (recommended):


### PR DESCRIPTION
### Description

Installing `ccache` with `sudo` makes it so the user doesn't have access to the `$HOME/.ccache` folder which causes ccache to fail. After taking ownership of those files, `ccache` works as expected

### Checklist
- [ ] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
