### PR TITLE
Patch for dead link in GSoC Blog post

### DIFF
--- a/_posts/2019-06-12-gsoc-2019-collision-detection.md
+++ b/_posts/2019-06-12-gsoc-2019-collision-detection.md
@@ -49,4 +49,4 @@ robotics experts. Besides coding this summer, he can be found  practicing Aikido
 
 **Useful Links**
 * [Main Github issue](https://github.com/ros-planning/moveit/issues/1427)
-* [MoveIt fork](https://github.com/j-petit/moveit/tree/integrating_bullet)
+* [MoveIt fork](https://github.com/j-petit/moveit)


### PR DESCRIPTION
### Description
I removed some old branches and broke a link in the GSoC blog post. This fixes the link. See [here](https://github.com/ros-planning/moveit.ros.org/pull/328#issuecomment-524417416) for issue.
