### PR TITLE
Fix typo in source install doc

### DIFF
--- a/install/source/index.markdown
+++ b/install/source/index.markdown
@@ -39,7 +39,7 @@ Optionally create a new workspace, you can name it whatever:
 
 Next, source your ROS workspace to load the necessary environment variables, depending on what version of ROS you installed.
 
-Choose one of the three:
+Choose one of the two:
 
     source /opt/ros/melodic/setup.bash
     source /opt/ros/kinetic/setup.bash


### PR DESCRIPTION
### Description

Fixed a single word typo in source install instructions.

### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
