### PR TITLE
Updated c++ version from c++11 to c++14

### DIFF
--- a/documentation/contributing/code/index.markdown
+++ b/documentation/contributing/code/index.markdown
@@ -18,7 +18,7 @@ In addition MoveIt has some extra style preferences:
 
 ## C++
 
- - We use C++11
+ - We use C++14
  - Use the C++ standard library (``std::``) whenever possible
  - Avoid C-style functions such as ``FLT_EPSILON`` - instead use ``std::numeric_limits<double>::epsilon()``
  - Boost is an encouraged library when functionality is not available in the standard library


### PR DESCRIPTION
### Description
There was conflicting information about the c++ version used. 
Now all c++ versions are c++14.