### PR TITLE
Clarify MoveIt dependencies vs core MoveIt repos

### DIFF
--- a/_posts/2019-08-05-world-moveit-day-2019.md
+++ b/_posts/2019-08-05-world-moveit-day-2019.md
@@ -65,7 +65,6 @@ Please state your intent to join or host the international event on [this form](
   - Organizer: Amel Ali
 - USA, ID, Pocatello, [Idaho State University](https://www.isu.edu)
   - Organizer: Omid Heidari
-  - [Event details](https://www.isu.edu/cse/moveitday/)
 
 If you aren’t near an organized event we encourage you to have your own event in your lab/organization/company and video conference in to all the other events.
 We would also like to mail your team or event some MoveIt stickers to schwag out your robots with. State your intent to join or host on
@@ -129,4 +128,3 @@ Join the video conference on [Appear.In](https://whereby.com/worldmoveitday19)
 - <img src="/assets/images/sponsors/swri.jpg" width="200"/>
 - <img src="/assets/images/sponsors/tokyo_os_logo.png" width="200"/>
 - <img src="/assets/images/sponsors/omronsinicx_logo.jpeg" width="200"/>
-

--- a/documentation/source-code-api/index.markdown
+++ b/documentation/source-code-api/index.markdown
@@ -44,11 +44,14 @@ MoveIt code is hosted on GitHub in the [ros-planning organization](http://github
 - [moveit_advanced](https://github.com/ros-planning/moveit_advanced) - Experimental advanced capabilities
 - [moveit_ci](https://github.com/ros-planning/moveit_ci) - script to run with Travis for continuous integration
 - [rqt_moveit](https://github.com/ros-visualization/rqt_moveit/) - Plugin for the GUI framework of ROS, RQT
-- [srdfdom](https://github.com/ros-planning/srdfdom) - Semantic Robot Description Format
+- [srdfdom](https://github.com/ros-planning/srdfdom) - Semantic Robot Description Format used exclusively by MoveIt
+
+Dependencies maintained by the ros-planning MoveIt team:
+
 - [warehouse_ros](https://github.com/ros-planning/warehouse_ros) - Abstract interface for persisting ROS message data
 - [random_numbers](https://github.com/ros-planning/random_numbers) - package for generating random numbers
 
-For completeness, the following repos are where documentation can be found:
+The following repos are where documentation can be found:
 
 - [moveit.ros.org](https://github.com/ros-planning/moveit.ros.org) - this main website
 - [moveit_tutorials](https://github.com/ros-planning/moveit_tutorials) - step by step examples for learning MoveIt


### PR DESCRIPTION
I'm working on measuring WMD stats and want to have a notion of what repos are officially "MoveIt". I think random_numbers and warehouse_ros should not be.