### PR TITLE
Rebrand 'PickNik Consulting' to 'PickNik Robotics'

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
         </a>
         <p>
           Brought to you by
-          <a href="https://picknik.ai/" target="_blank">PickNik Consulting</a><br />and these <a href="http://moveit.ros.org/about/">awesome maintainers</a><br />
+          <a href="https://picknik.ai/" target="_blank">PickNik Robotics</a><br />and these <a href="http://moveit.ros.org/about/">awesome maintainers</a><br />
           <a href="https://picknik.ai/donate-to-moveit" target="_blank">Donate today!</a>
         </p>
         <a class="button" target="_blank" href="/about/get_involved/">GET INVOLVED</a>

--- a/documentation/contributing/future_projects/index.markdown
+++ b/documentation/contributing/future_projects/index.markdown
@@ -11,7 +11,7 @@ title: Code Sprints
 
 <img src="/assets/logo/moveit_logo-black.png" width="300"/>
 
-This page lists potential projects that would greatly benefit the MoveIt project. This is by no means an exhaustive list, but is meant to serve as a discussion starting point for code sprints and other efforts. Please contact [PickNik Consulting](https://picknik.ai/connect/) for further information or sponsorship opportunities.
+This page lists potential projects that would greatly benefit the MoveIt project. This is by no means an exhaustive list, but is meant to serve as a discussion starting point for code sprints and other efforts. Please contact [PickNik Robotics](https://picknik.ai/connect/) for further information or sponsorship opportunities.
 
 ## TrajOpt Integration and Related Work on Trajectory Optimization Methods
 

--- a/documentation/faqs/index.markdown
+++ b/documentation/faqs/index.markdown
@@ -89,7 +89,7 @@ _I have a found a bug in MoveIt itself. What should I do?_
 
 _I would like to add a new robot to the list of robots using MoveIt. What should I do?_
 
-  * Create a pull request to [moveit.ros.org's Github repo](https://github.com/ros-planning/moveit.ros.org) or email [PickNik Consulting](http://picknik.ai/connect) for additional assitance.
+  * Create a pull request to [moveit.ros.org's Github repo](https://github.com/ros-planning/moveit.ros.org) or email [PickNik Robotics](http://picknik.ai/connect) for additional assitance.
 
 _What robots does MoveIt support?_
 

--- a/events/world-moveit-day-2017/index.markdown
+++ b/events/world-moveit-day-2017/index.markdown
@@ -31,7 +31,7 @@ World MoveIt Day is an international hackathon to improve the MoveIt code base, 
   - Contact: Andreas Köpf
 - [ROS-Industrial Asian Pacific Consortium](http://rosindustrial.org/ric-apac/), Singapore
   - Contact: Chan Min Ling
-- [PickNik Consulting (Univ. Colorado)](http://picknik.ai), Boulder, USA
+- [PickNik Robotics (Univ. Colorado)](http://picknik.ai), Boulder, USA
   - Contact: Andy McEvoy
 - [Shadow Robot Company](https://www.shadowrobot.com), London, UK
   - Contact: Ugo Cupcic
@@ -44,7 +44,7 @@ World MoveIt Day is an international hackathon to improve the MoveIt code base, 
 
 ## Organizers
 
-  * Dave Coleman, PickNik Consulting
+  * Dave Coleman, PickNik Robotics
   * Michael Görner, University of Hamburg, Group TAMS
 
 ## Signup
@@ -63,7 +63,7 @@ Please state your intent to join the international event [on this form](https://
 
 **ROS-Industrial Asian Pacific Consortium** EVENT ON THURSDAY OCTOBER 19th due to a national holiday. Lunch will be provided. To register and obtain the video conference details please sign up here: [EventBrite](https://www.eventbrite.sg/e/world-moveit-day-asia-pacific-tickets-38378316578).
 
-**PickNik Consulting** will be hosting an event at the University of Colorado Computer Science Robotics lab in the Engineering Center. Lunch will be provided. RSVP here: [Meetup](https://www.meetup.com/BoulderIsForRobots/events/243990181/).
+**PickNik Robotics** will be hosting an event at the University of Colorado Computer Science Robotics lab in the Engineering Center. Lunch will be provided. RSVP here: [Meetup](https://www.meetup.com/BoulderIsForRobots/events/243990181/).
 
 **Shadow Robot** will either be held at our office in Islington or at UCL's place in Here East (both venues in London). In particular, we'd like to show you a demo of what we're doing with our hardware. For more information see [EventBrite](https://www.eventbrite.co.uk/e/world-moveit-day-shadow-robot-company-ucl-hackathon-tickets-38493613434)
 

--- a/events/world-moveit-day-2018/index.markdown
+++ b/events/world-moveit-day-2018/index.markdown
@@ -24,7 +24,7 @@ World MoveIt Day is an international hackathon to improve the MoveIt code base, 
 - [Iron Ox](http://ironox.com), San Francisco, USA
   - Organizer: Jon Binnery
   - [Event details](https://www.eventbrite.com/e/world-moveit-day-2018-bay-area-tickets-49609912584)
-- [PickNik Consulting](http://picknik.ai), Boulder, USA
+- [PickNik Robotics](http://picknik.ai), Boulder, USA
   - Organizer: Dave Coleman
   - [Event details](https://www.meetup.com/BoulderIsForRobots/events/254921086/)
 - [Fraunhofer IPA](https://www.ipa.fraunhofer.de/en.html) / [RIC-EU](https://rosindustrial.org/ric-eu/), Stuttgart, Germany
@@ -48,7 +48,7 @@ World MoveIt Day is an international hackathon to improve the MoveIt code base, 
 
 ## General Information Contacts
 
-  * Dave Coleman, Nathan Brooks, Rob Coleman // PickNik Consulting
+  * Dave Coleman, Nathan Brooks, Rob Coleman // PickNik Robotics
 
 ## Signup
 
@@ -98,7 +98,7 @@ Joint the video conference on [Appear.In](https://appear.in/moveit2)
 
 We'd like to thank the following sponsors:
 
-[<img src="/assets/images/wmd18/picknik_logo.png" alt="PickNik Consulting" width="200" css="margin-right:20px"/>](http://picknik.ai)
+[<img src="/assets/images/wmd18/picknik_logo.png" alt="PickNik Robotics" width="200" css="margin-right:20px"/>](http://picknik.ai)
 
 [<img src="/assets/images/wmd18/iron_ox_logo.png" alt="Iron Ox" width="150" css="margin-right:20px"/>](http://ironox.com)
 

--- a/robots/index.markdown
+++ b/robots/index.markdown
@@ -14,7 +14,7 @@ title: Robots
 				<h1>{{page.title}}</h1>
 				<p>MoveIt has been used on over 126 robots by the community. From deep sea to outerspace, from hobbiests to industrial applications, check out a few of the many examples below using MoveIt with different robots.</p>
 				<hr/>
-				<p>See something missing? If you would like to add a robot to this list, please contact <a href="http://picknik.ai/">PickNik Consulting</a></p>
+				<p>See something missing? If you would like to add a robot to this list, please contact <a href="http://picknik.ai/">PickNik Robotics</a></p>
 				<p>We are also looking for robot maintainers and new robots. If you are willing to maintain the MoveIt packages for any robot in this list please post on the <a href="https://discourse.ros.org/c/moveit" target="_blank">ROS Discourse category</a>.</p>
 			</div>
 		</div>
@@ -1638,7 +1638,7 @@ title: Robots
 		<div class="col-xs-12 col-sm-12">
 			<div class="robots-main--bottom">
 				<hr/>
-				<p><strong>Need Custom Development?</strong> If you need help with integration of MoveIt on your robot or applications, please contact <a href="http://picknik.ai/connect" target="_blank">PickNik Consulting</a>
+				<p><strong>Need Custom Development?</strong> If you need help with integration of MoveIt on your robot or applications, please contact <a href="http://picknik.ai/connect" target="_blank">PickNik Robotics</a>
 				</p>
 			</div>
 		</div>

--- a/support/index.markdown
+++ b/support/index.markdown
@@ -11,7 +11,7 @@ title: Support
 
 ## Professional Support
 
-[PickNik Consulting](http://picknik.ai/) was founded with the mission of growing the MoveIt project through community building and sponsored development.
+[PickNik Robotics](http://picknik.ai/) was founded with the mission of growing the MoveIt project through community building and sponsored development.
 We offer [ongoing MoveIt support](https://picknik.ai/services/moveit/) plans as well as custom code development.
 If you are with a company or organization that may be interested, contact us for a free consultation call.
 


### PR DESCRIPTION
We've been moving away from using the term "Consulting" the past year, let's make it consistent here also.