### PR TITLE
Add IRC to Get Involved page

### DIFF
--- a/about/get_involved/index.markdown
+++ b/about/get_involved/index.markdown
@@ -1,6 +1,4 @@
 ---
-author: davetcoleman
-comments: false
 date: 2018-11-09 04:37:44+00:00
 layout: page
 slug: get-involved
@@ -9,20 +7,26 @@ title: Get Involved
 
 # Get Involved
 
+## MoveIt on Discourse
+
 Follow MoveIt on [ROS Discourse](http://discourse.ros.org/c/moveit) for project announcements, discussion of future development, maintenance, testing, and releases.
 
 To subscribe via email (recommended):
 
   * Login or create an account at the top right of the [MoveIt Discourse](http://discourse.ros.org/c/moveit) channel
-  * On the [MoveIt Discourse](http://discourse.ros.org/c/moveit) channel page, click the small circle at the top right (see screenshot below).
+  * On the MoveIt Discourse channel page, click the small circle at the top right (see screenshot below).
   * Set the notification status to "Watching" or similar setting.
 
-<img src="{{ site.url }}/assets/images/discourse_subscribe.png" width="900"/>
+<img src="{{ site.url }}/assets/images/discourse_subscribe.png" width="700"/>
 
-<br /><br /><br />
+<br /><br />
 
 Note that this Discourse forum is not for MoveIt users questions or specific robot application questions. *Technical questions should be directed to [answers.ros.org](http://answers.ros.org/) with the moveit tag*.
 
-## Other Ways of Getting Involved
+## IRC
+
+For old school hackers, check out our IRC channel with #moveit at irc.freenode.net.
+
+## Contributing
 
 See the [Contributing](http://moveit.ros.org/documentation/contributing/) page.


### PR DESCRIPTION
@v4hn [likes IRC](https://github.com/ros-planning/moveit.ros.org/pull/447#issuecomment-636985559), so I added it here:

> Either way I'm not ok with removing the IRC link. There are around 6 regulars in that channel. smile

