### PR TITLE
Make LOGNAME constexpr char instead of const std::string

### DIFF
--- a/documentation/contributing/code/index.markdown
+++ b/documentation/contributing/code/index.markdown
@@ -54,7 +54,7 @@ In addition MoveIt has some extra style preferences:
 
  - The ROS logging functionality is utilized and namespaced. i.e. ``ROS_INFO_NAMED(LOGNAME, "Starting listener...``.
    - This makes it easier to understand where output is coming from on the command line and allows for more fine-grained filtering of terminal output noise.
-   - Your logging namespace is defined as a ``const`` variable. (eg: ``const std::string LOGNAME = "robot_state";``)
+   - Your logging namespace is defined as a ``const`` variable. (eg: ``constexpr char LOGNAME[] = "robot_state";``)
    - The use of the file name as the NAMED namespace is best practice, i.e. planning_scene.cpp would use ``"planning_scene"``
    - Avoid using the package name as the namespace as this is already output by the logger
 


### PR DESCRIPTION
### Description

@mamoll proposed to change `const std::string LOGNAME` to `constexpr char LOGNAME[]` in [this review comment](https://github.com/ros-planning/moveit/pull/2211#discussion_r456514909). Should we update it here?

### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
