### PR TITLE
Fix missing link in 'Running MoveIt Containers' section

### DIFF
--- a/install/docker/index.markdown
+++ b/install/docker/index.markdown
@@ -39,7 +39,7 @@ title: MoveIt 1 Docker Install
     <div class="horizontal-line"></div>
     <h2>Running MoveIt Containers</h2>
     <p>
-      To use Rviz (and other GUIs), you probably want to set up hardware acceleration for Docker as described here.
+      To use Rviz (and other GUIs), you probably want to set up hardware acceleration for Docker as described <a href="http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration" target="_blank">here</a>.
     </p>
     <br/>
     <p>


### PR DESCRIPTION
### Description

Fix: https://github.com/ros-planning/moveit.ros.org/issues/477

### Checklist
- [ ] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
