### PR TITLE
Update MoveIt 2 install instructions to Foxy

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -371,7 +371,7 @@ redirect_from: '/moveit/'
                         <p><span>Platforms:</span> Ubuntu 18.04</p>
                         <p><span>Initial release:</span> 14 February 2020</p>
                         <p><span>End of life:</span> November 2020</p>
-                        <p><span>Branch:</span> <a href="https://github.com/ros-planning/moveit2" target="_blank">moveit2:master</a></p>
+                        <p><span>Branch:</span> <a href="https://github.com/ros-planning/moveit2/tree/eloquent" target="_blank">moveit2:eloquent</a></p>
                     </div>
                     <div class="version-content">
                         <h4>Release notes</h4>

--- a/install-moveit2/source/index.markdown
+++ b/install-moveit2/source/index.markdown
@@ -12,20 +12,19 @@ Installing MoveIt 2 from source is the first step in contributing new features, 
 
 MoveIt is mainly supported on Linux, and the following build instructions support in particular:
 
-- Ubuntu 18.04 / ROS 2 Eloquent
-- Ubuntu 20.04 / ROS 2 Foxy (Releasing July 2020)
+- Ubuntu 20.04 / ROS 2 Foxy Fitzroy
 
 In the future, we would like to expand our source build instructions to more OS's, please contribute instruction write-ups to [this repo](https://github.com/ros-planning/moveit.ros.org).
 
-These instructions assume you are running on Ubuntu 18.04.
+These instructions assume you are running on Ubuntu 20.04.
 
 ## Prerequisites
 
 ### Install <img src="/assets/install_page/ros_logo.jpeg"/>
 
-[Install ROS2 Eloquent](https://index.ros.org/doc/ros2/Installation/Eloquent/Linux-Install-Debians/) following the installation instructions. Use the desktop installation and don't forget to source the setup script.
+[Install ROS2 Foxy](https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Debians/) following the installation instructions. Use the desktop installation and don't forget to source the setup script.
 
-[Install ROS2 Build Tools](https://index.ros.org/doc/ros2/Installation/Linux-Development-Setup/#install-development-tools-and-ros-tools) up until setting up rosdep (we're using slightly different steps for setting up our workspace)
+[Install ROS2 Build Tools](https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-development-tools-and-ros-tools) up until setting up rosdep (we're using slightly different steps for setting up our workspace)
 
 ### Create Workspace and Source
 
@@ -41,7 +40,7 @@ Download the repository and install any dependencies:
 
     git clone https://github.com/ros-planning/moveit2.git -b master
     vcs import < moveit2/moveit2.repos
-    rosdep install -r --from-paths . --ignore-src --rosdistro eloquent -y
+    rosdep install -r --from-paths . --ignore-src --rosdistro foxy -y
 
 ## Build MoveIt
 
@@ -50,7 +49,7 @@ Configure and build the workspace:
     cd $COLCON_WS
     colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release
 
-### Source the Catkin Workspace
+### Source the Colcon Workspace
 
 Setup your environment - you can do this every time you work with this particular source install of the code, or you can add this to your ``.bashrc`` (recommended):
 


### PR DESCRIPTION
Additionally, updates abandoned ROS2 versions (Dashing,Eloquent) branches and EOL dates.
Should be merged once https://github.com/ros-planning/moveit2/pull/227 is merged.