### PR TITLE
add feedback form

### DIFF
--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -1,0 +1,23 @@
+<div class="alert alert-info alert-dismissible fade show" role="alert">
+  <p>Please consider providing some quick feedback on how you plan to use MoveIt by clicking the button below. This is
+    essential to help obtain government funding for further development and prioritize milestones on our roadmap.</p>
+  <button type="button" class="btn btn-info btn-lg" data-toggle="modal" data-target="#feedbackform">Submit
+    feedback</button>
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+
+
+<div class="modal feedback-modal fade" id="feedbackform" tabindex="-1" role="dialog" aria-labelledby="feedbackformlabel"
+  aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        <iframe id="google-feedback-form"
+          src="https://docs.google.com/forms/d/e/1FAIpQLScrMFZYi9UJJP8qGd-rcZ4SsrYFSJY57R6sll_dlScezsmQAg/viewform?embedded=true"
+          width="700" height="1133" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/install-feedback.html
+++ b/_includes/install-feedback.html
@@ -1,6 +1,5 @@
 <div class="alert alert-info alert-dismissible fade show" role="alert">
-  <p>Please consider providing some quick feedback on how you plan to use MoveIt by clicking the button below. This is
-    essential to help obtain government funding for further development and prioritize milestones on our roadmap.</p>
+  <p>Please consider providing some quick feedback on how you plan to use MoveIt to help us obtain government funding for further development and prioritize milestones on our roadmap.</p>
   <button type="button" class="btn btn-info btn-lg" data-toggle="modal" data-target="#feedbackform">Submit
     feedback</button>
   <button type="button" class="close" data-dismiss="alert" aria-label="Close">
@@ -16,7 +15,7 @@
       <div class="modal-body">
         <iframe id="google-feedback-form"
           src="https://docs.google.com/forms/d/e/1FAIpQLScrMFZYi9UJJP8qGd-rcZ4SsrYFSJY57R6sll_dlScezsmQAg/viewform?embedded=true"
-          width="700" height="1133" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+          width="700" height="700px" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
       </div>
     </div>
   </div>

--- a/_sass/_feedback.scss
+++ b/_sass/_feedback.scss
@@ -7,6 +7,6 @@
     -o-transform: translateY(-30%);
     height: 100%;
 
-    .modal-content { width: 700px; }
-    .modal-dialog { max-width: 700px; }
+    .modal-content { width: 720px; }
+    .modal-dialog { max-width: 720px; }
 }

--- a/_sass/_feedback.scss
+++ b/_sass/_feedback.scss
@@ -1,0 +1,12 @@
+.feedback-modal {
+    top: 30%;
+    transform: translateY(-30%);
+    -webkit-transform: translateY(-30%);
+    -moz-transform: translateY(-30%);
+    -ms-transform: translateY(-30%);
+    -o-transform: translateY(-30%);
+    height: 100%;
+
+    .modal-content { width: 700px; }
+    .modal-dialog { max-width: 700px; }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -19,3 +19,4 @@
 @import 'modal';
 @import 'install';
 @import 'people';
+@import 'feedback';

--- a/install-moveit2/source/index.markdown
+++ b/install-moveit2/source/index.markdown
@@ -3,7 +3,7 @@ layout: install
 slug: source_install_moveit2
 title: MoveIt 2 Source Build - Linux
 ---
-{% include feedback.html %}
+{% include install-feedback.html %}
 
 # MoveIt 2 Source Build - Linux
 

--- a/install-moveit2/source/index.markdown
+++ b/install-moveit2/source/index.markdown
@@ -3,6 +3,7 @@ layout: install
 slug: source_install_moveit2
 title: MoveIt 2 Source Build - Linux
 ---
+{% include feedback.html %}
 
 # MoveIt 2 Source Build - Linux
 


### PR DESCRIPTION

![feedback-form](https://user-images.githubusercontent.com/2381200/90358654-8d69ba80-e00b-11ea-8730-3717f28bc930.gif)

### Description

This adds a feedback form to the MoveIt 2 installation page via a modal display. The form can be added to any other page with one include statement. Styling the google form to make it look better requires some javascript trickery, but I am not sure it's worth the trouble. Responses are collected here: https://docs.google.com/forms/d/1ZtJKOkQO2abblN0eC2bvzz5KRvRucSoHnvzWCJmLGQ4/edit#response=ACYDBNg4c9BBUtTEPbqDhY7phpMNwAxfHblrcmlkzH9CRFkS8lUup4siMeGiJVyoPdNuwA8
 
### Checklist
- [ ] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
