### PR TITLE
Remove old redirects that break travis

### DIFF
--- a/_posts/2014-02-20-first-new-robot-2014-hollie.markdown
+++ b/_posts/2014-02-20-first-new-robot-2014-hollie.markdown
@@ -8,8 +8,6 @@ title: First new robot of 2014 - HoLLiE
 description: HoLLiE is an Acronym for “House of Living Labs intelligent Escort“ and was developed at the FZI Karlsruhe as part of the “House of Living Labs” (HoLL).
 media_type: image
 media_link: /assets/images/robots/hollie.png
-redirect_from:
-  - "/first-new-robot-2014-hollie/"
 categories:
 - General
 ---

--- a/_posts/2014-04-03-rossurvey.markdown
+++ b/_posts/2014-04-03-rossurvey.markdown
@@ -6,8 +6,6 @@ layout: post
 slug: rossurvey
 title: MoveIt! scores high in the ROS survey
 description: New ROS survey results are out and MoveIt! scored high on the list of ROS packages important to users.
-redirect_from:
-  - "/rossurvey/"
 categories:
   - MoveIt!
   - ROS

--- a/_posts/2015-03-17-versatile-manipulation-baxter-robot-with-moveit-used-to-teach-robotics-fundamentals-at-columbia-university.markdown
+++ b/_posts/2015-03-17-versatile-manipulation-baxter-robot-with-moveit-used-to-teach-robotics-fundamentals-at-columbia-university.markdown
@@ -8,8 +8,6 @@ title: 'Versatile Manipulation: Baxter Robot with MoveIt! Used to Teach Robotics
 description: From factory assembly lines to warehouses and living rooms, robots are always expanding their role in our lives. Both hardware and software are critical for this transformation, so students taking the Intro to Robotics class in Columbia University’s Mechanical Engineering Dept. are using a Baxter Robot (Rethink Robotics Inc.) along with MoveIt! to learn robotics fundamentals. ...
 media_type: image
 media_link: /assets/images/blog_posts/baxter_at_columbia/IMG_1.jpg
-redirect_from:
-  - "/versatile-manipulation-baxter-robot-with-moveit-used-to-teach-robotics-fundamentals-at-columbia-university/"
 categories:
 - MoveIt!
 - ROS


### PR DESCRIPTION
Otherwise ``./build_locally.sh traivs`` fails

From 2014 so don't need these redirects anymore