### PR TITLE
[Windows] updated to the latest feed URL.

### DIFF
--- a/install/index.markdown
+++ b/install/index.markdown
@@ -156,7 +156,7 @@ title: MoveIt 1 Binary Install
           <code>
             mkdir c:\opt\chocolatey<br/>
             set ChocolateyInstall=c:\opt\chocolatey<br/>
-            choco source add -n=ros-win -s="https://roswin.azurewebsites.net/api/v2" --priority=1<br/>
+            choco source add -n=ros-win -s="https://aka.ms/ros/public" --priority=1<br/>
           </code>
         </div>
         <p>

--- a/install/source-windows/index.markdown
+++ b/install/source-windows/index.markdown
@@ -49,7 +49,7 @@ title: MoveIt 1 Source Build - Windows
         <br/>
         :: attempt to acquire the external dependencies<br/>
         set ChocolateyInstall=c:\opt\chocolatey<br/>
-        choco source add -n=ros-win -s="https://roswin.azurewebsites.net/api/v2" --priority=1<br/>
+        choco source add -n=ros-win -s="https://aka.ms/ros/public" --priority=1<br/>
         rosdep update<br/>
         rosdep install --from-paths src --ignore-src -r -y<br/>
         pip install --upgrade --force-reinstall cmake==3.16.3


### PR DESCRIPTION
### Description

Updated the feed URL for Windows installation. The migration reminder can be found [here](https://discourse.ros.org/t/reminder-https-aka-ms-ros-public-the-new-chocolatey-feed-url-for-ros-on-windows/16098).

### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
