### PR TITLE
Errors in build from source instructions, fix and harmonize 

### DIFF
--- a/install-moveit2/source/index.markdown
+++ b/install-moveit2/source/index.markdown
@@ -39,8 +39,8 @@ Create a colcon workspace:
 
 Download the repository and install any dependencies:
 
-    git clone https://github.com/ros-planning/moveit2.git -b main
-    vcs import < moveit2/moveit2.repos
+    wget https://raw.githubusercontent.com/ros-planning/moveit2/main/moveit2.repos
+    vcs import < moveit2.repos
     rosdep install -r --from-paths . --ignore-src --rosdistro foxy -y
 
 ## Build MoveIt


### PR DESCRIPTION

### Description

Current instructions will cause errors while importing repos. 
Moreover it somewhat breaks the flow of most other instructions
or ros2 here repos are fetched to later vcs import them.

This PR proposes changes to do exactly this.


