### PR TITLE
Improved Install Instructions for rosdep #2416

### DIFF
--- a/install/source/index.markdown
+++ b/install/source/index.markdown
@@ -31,7 +31,7 @@ title: MoveIt 1 Source Build - Linux
     <p>Source installation requires <a href="http://wiki.ros.org/wstool" target="_blank">wstool</a>, <a href="https://catkin-tools.readthedocs.io/en/latest/" target="_blank">catkin_tools</a>, and optionally <a href="https://clang.llvm.org/docs/ClangFormat.html" target="_blank">clang-format</a>:</p>
     <div class="bash-command">
         <code>
-            sudo apt install python3-wstool python3-catkin-tools clang-format-10
+            sudo apt install python3-wstool python3-catkin-tools clang-format-10 python3-rosdep
         </code>
     </div>
     <p><i>Kinetic/Melodic Note: for Ubuntu 16.04 and 18.04, replace 'python3' with just 'python'</i></p>


### PR DESCRIPTION
Updated install instructions for moveit prerequisites which fixes issue  ros-planning/moveit#2416
