### PR TITLE
Add pilz industrial motion planner

### DIFF
--- a/documentation/planners/index.markdown
+++ b/documentation/planners/index.markdown
@@ -16,7 +16,7 @@ MoveIt is designed to work with many different types of planners, which is ideal
 OMPL is an open-source motion planning library that primarily implements randomized motion planners. MoveIt integrates directly with OMPL and uses the motion planners from that library as its primary/default set of planners. The planners in OMPL are abstract; i.e. OMPL has no concept of a robot. Instead, MoveIt configures OMPL and provides the back-end for OMPL to work with problems in Robotics. Fully supported. [More Info](http://ompl.kavrakilab.org/)
 
 ## Pilz Industrial Motion Planner
-Pilz industrial motion planner is a generator for circular or linear motions in a rapid and *predictable* way. Additionally, it supports blending multiple motion segments together with a MoveIt capability.
+Pilz industrial motion planner is a deterministic generator for circular and linear motions. Additionally, it supports blending multiple motion segments together using a MoveIt capability.
 
 ## Stochastic Trajectory Optimization for Motion Planning (STOMP)
 

--- a/documentation/planners/index.markdown
+++ b/documentation/planners/index.markdown
@@ -11,12 +11,12 @@ title: Planners
 
 MoveIt is designed to work with many different types of planners, which is ideal for benchmarking improved planners against previous methods. Below is a list of planners that have been used with MoveIt, in descending order of popularity/support within MoveIt:
 
-## Pilz Industrial Motion Planner
-Pilz industrial motion planner supports solving for circular or linear motions in a rapid and **predictable** way. Additionally, it supports blending multiple motion segments together with a MoveIt capability.
-
 ## Open Motion Planning Library (OMPL)
 
 OMPL is an open-source motion planning library that primarily implements randomized motion planners. MoveIt integrates directly with OMPL and uses the motion planners from that library as its primary/default set of planners. The planners in OMPL are abstract; i.e. OMPL has no concept of a robot. Instead, MoveIt configures OMPL and provides the back-end for OMPL to work with problems in Robotics. Fully supported. [More Info](http://ompl.kavrakilab.org/)
+
+## Pilz Industrial Motion Planner
+Pilz industrial motion planner is a generator for circular or linear motions in a rapid and *predictable* way. Additionally, it supports blending multiple motion segments together with a MoveIt capability.
 
 ## Stochastic Trajectory Optimization for Motion Planning (STOMP)
 

--- a/documentation/planners/index.markdown
+++ b/documentation/planners/index.markdown
@@ -11,6 +11,9 @@ title: Planners
 
 MoveIt is designed to work with many different types of planners, which is ideal for benchmarking improved planners against previous methods. Below is a list of planners that have been used with MoveIt, in descending order of popularity/support within MoveIt:
 
+## Pilz Industrial Motion Planner
+Pilz industrial motion planner supports solving for circular or linear motions in a rapid and **predictable** way. Additionally, it supports blending multiple motion segments together with a MoveIt capability.
+
 ## Open Motion Planning Library (OMPL)
 
 OMPL is an open-source motion planning library that primarily implements randomized motion planners. MoveIt integrates directly with OMPL and uses the motion planners from that library as its primary/default set of planners. The planners in OMPL are abstract; i.e. OMPL has no concept of a robot. Instead, MoveIt configures OMPL and provides the back-end for OMPL to work with problems in Robotics. Fully supported. [More Info](http://ompl.kavrakilab.org/)


### PR DESCRIPTION
### Description

A short description for the pilz_industrial_motion_planner was added to the planner documentation page.

### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
