### PR TITLE
remove https from all links to tutorials page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,7 +28,7 @@
             <h4>DOCS</h4>
             <ul>
               <li>
-                <a target="_blank" href="https://moveit2_tutorials.picknik.ai/">Tutorials</a>
+                <a target="_blank" href="http://moveit2_tutorials.picknik.ai/">Tutorials</a>
               </li>
               <li>
                 <a href="/documentation/applications/">Applications</a>

--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -34,11 +34,11 @@
             </div>
           </li>
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="https://moveit2_tutorials.picknik.ai/" id="navbarDropdownDocs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="nav-link dropdown-toggle" href="http://moveit2_tutorials.picknik.ai/" id="navbarDropdownDocs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Docs
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownDocs">
-              <a class="dropdown-item" target="_blank" href="https://moveit2_tutorials.picknik.ai/">Tutorials</a>
+              <a class="dropdown-item" target="_blank" href="http://moveit2_tutorials.picknik.ai/">Tutorials</a>
               <a class="dropdown-item" href="/documentation/applications/">Applications</a>
               <a class="dropdown-item" href="/documentation/concepts/">Concepts</a>
               <a class="dropdown-item" href="/documentation/related_projects/">Related Projects</a>

--- a/documentation/applications/index.markdown
+++ b/documentation/applications/index.markdown
@@ -9,7 +9,7 @@ title: Applications
 
 # MoveIt Applications
 
-There are many diverse application examples of what you can use MoveIt for. The list below demonstrates some of the advanced applications developed on MoveIt. You can have fun by trying the applications, which may help you figure out how to fit different features together. If you are interested, you can visit [MoveIt Tutorials](https://moveit2_tutorials.picknik.ai/) for further technical details. At the same time, your contribution is encouraged, no matter the application is developed for some usages, competitions or research topics, or to demonstrate the newly developed MoveIt feature.
+There are many diverse application examples of what you can use MoveIt for. The list below demonstrates some of the advanced applications developed on MoveIt. You can have fun by trying the applications, which may help you figure out how to fit different features together. If you are interested, you can visit [MoveIt Tutorials](http://moveit2_tutorials.picknik.ai/) for further technical details. At the same time, your contribution is encouraged, no matter the application is developed for some usages, competitions or research topics, or to demonstrate the newly developed MoveIt feature.
 
 ## MoveIt Example Apps
 

--- a/documentation/concepts/index.markdown
+++ b/documentation/concepts/index.markdown
@@ -9,7 +9,7 @@ title: Concepts
 
 # Concepts
 
-The following is an overview of how MoveIt works. For more concrete documentation and details see the [tutorials](https://moveit2_tutorials.picknik.ai/) or the [developers' concepts](/documentation/concepts/developer_concepts/).
+The following is an overview of how MoveIt works. For more concrete documentation and details see the [tutorials](http://moveit2_tutorials.picknik.ai/) or the [developers' concepts](/documentation/concepts/developer_concepts/).
 
 ## System Architecture
 
@@ -30,7 +30,7 @@ The users can access the actions and services provided by _move_group_ in one of
 
 - **In Python** - using the [moveit_commander](http://docs.ros.org/noetic/api/moveit_commander/html/classmoveit__commander_1_1move__group_1_1MoveGroupCommander.html) package
 
-- **Through a GUI** - using the [Motion Planning plugin to Rviz](https://moveit2_tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html) (the ROS visualizer)
+- **Through a GUI** - using the [Motion Planning plugin to Rviz](http://moveit2_tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html) (the ROS visualizer)
 
 _move_group_ can be configured using the ROS param server from where it will also get the URDF and SRDF for the robot.
 
@@ -173,7 +173,7 @@ MoveIt uses a plugin infrastructure, especially targeted towards allowing users 
 
 ### **IKFast Plugin**
 
-Often, users may choose to implement their own kinematics solvers, e.g. the PR2 has its own kinematics solvers. A popular approach to implementing such a solver is using the [IKFast package](https://moveit2_tutorials.picknik.ai/doc/ikfast/ikfast_tutorial.html) to generate the C++ code needed to work with your particular robot.
+Often, users may choose to implement their own kinematics solvers, e.g. the PR2 has its own kinematics solvers. A popular approach to implementing such a solver is using the [IKFast package](http://moveit2_tutorials.picknik.ai/doc/ikfast/ikfast_tutorial.html) to generate the C++ code needed to work with your particular robot.
 
 ---
 

--- a/documentation/faqs/index.markdown
+++ b/documentation/faqs/index.markdown
@@ -15,7 +15,7 @@ title: FAQs
 
 _I'm totally new, how do I get started?_
 
-  * See the [tutorials](https://moveit2_tutorials.picknik.ai/) &#128540;
+  * See the [tutorials](http://moveit2_tutorials.picknik.ai/) &#128540;
 
 _What version of MoveIt should I use?_
 


### PR DESCRIPTION
### Description

HTTPS cert is not working yet for MoveIt2_Tutorials, so set links to HTTP

### Checklist
- [ ] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
