### PR TITLE
Fix lightning talk formatting and minor issues

### DIFF
--- a/_posts/2021-03-23-world-moveit-day-2021-lighting-talks.md
+++ b/_posts/2021-03-23-world-moveit-day-2021-lighting-talks.md
@@ -14,28 +14,28 @@ categories:
 - MoveIt
 ---
 
-The 6th annual 2021 World MoveIt Day saw 90 MoveIt contributors from around the world come together to work on the open-source MoveIt project. With over 5000 lines of code written, 115 pull requests reviewed,, and 4 virtual meetups taking place on 3 continents.
+The 6th annual 2021 World MoveIt Day saw 90 MoveIt contributors from around the world come together to work on the open-source MoveIt project, with over 5000 lines of code written, 115 pull requests reviewed, and 4 virtual meetups taking place on 3 continents.
 
-Part of the event was a “lightning talk” submission. Where contributors submit a 120 second or less talk on a topic of their choice. Ideas range from what to work on to what the contributor has solved. Here are the 2021 submissions as hosted on Youtube.
+Part of the event was a “lightning talk” submission, where contributors submit a video of 120 seconds or less on a topic of their choice. Topics range from ideas about what to work on, to things that the contributor has solved. Here are the 2021 submissions as hosted on Youtube:
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/0uXkHMpu_L8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
- **Boston Cleek’s talk:** ROS2 ament_cmake tutorial on how to implement a symlink install.
+ **Boston Cleek**'s talk: ROS2 ament_cmake tutorial on how to implement a symlink install
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/IJzq8b3xLNo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-**Tyler Weaver’s** talk on ROS2 Depend on Boost Component Libraries
+**Tyler Weaver**'s talk: ROS2 Depend on Boost Component Libraries
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Q-RIQi5ru3o" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-[**Felix von Drigalski's**](https://twitter.com/FDrigalski) Lightning Talk on Visual planning.
+[**Felix von Drigalski**](https://twitter.com/FDrigalski)'s talk: Collision Object Visualization
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/DA81xMi_EZg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-[**John Stechschulte’s**](https://twitter.com/john_stech) Talk on MoveIt Calibration
+[**John Stechschulte**](https://twitter.com/john_stech)'s talk: MoveIt Calibration
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/QzXJWQumtNY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-[**David Lu’s**](https://twitter.com/probablydavid) talk on How to use MoveIt with Navigation
+[**David Lu**](https://twitter.com/probablydavid)'s talk: How to use MoveIt with Navigation
 
 ## Up Next: ##
 We’re still compiling data from the event and will keep you up to date on the outcomes in the coming week!


### PR DESCRIPTION
Fixes for typos and formatting in #575 which was merged before I could take a look.

If we could fix the topic name and "Lightening" typo in my talk's video, that would also be sweet.