### PR TITLE
Split contributing guide into "Pull Requests", "Development"

### DIFF
--- a/_includes/contribution-guide-nav.html
+++ b/_includes/contribution-guide-nav.html
@@ -45,7 +45,7 @@
           </div>
         </div>
   </a>
-  <a href="https://github.com/ros-planning/moveit2/pulls">
+  <a href="https://github.com/ros-planning/moveit2/pulls" target="_blank">
     {% if page.url == "https://github.com/ros-planning/moveit2/pulls" %}
     <div class="row no-gutters">
       <img src="/assets/install_page/current_page_left.png" class="current-page-image-left">

--- a/_includes/contribution-guide-nav.html
+++ b/_includes/contribution-guide-nav.html
@@ -31,7 +31,7 @@
         </div>
   </a>
   <div class="font-other-page"><b>See Pull Requests on GitHub:</b></div>
-  <a href="https://github.com/ros-planning/moveit/pulls">
+  <a href="https://github.com/ros-planning/moveit/pulls" target="_blank">
     {% if page.url == "https://github.com/ros-planning/moveit/pulls" %}
     <div class="row no-gutters">
       <img src="/assets/install_page/current_page_left.png" class="current-page-image-left">

--- a/_includes/contribution-guide-nav.html
+++ b/_includes/contribution-guide-nav.html
@@ -41,7 +41,7 @@
         <div>
           <div class="row font-other-page" style="text-indent: 10px">
             {% endif %}
-	    → MoveIt (ROS 1)
+	    → MoveIt 1
           </div>
         </div>
   </a>
@@ -55,7 +55,7 @@
         <div>
           <div class="row font-other-page" style="text-indent: 10px">
             {% endif %}
-	    → MoveIt (ROS 2)
+	    → MoveIt 2
           </div>
         </div>
   </a>

--- a/_includes/contribution-guide-nav.html
+++ b/_includes/contribution-guide-nav.html
@@ -30,20 +30,38 @@
           </div>
         </div>
   </a>
-  <a href="/documentation/contributing/releases/">
-    {% if page.url == "/documentation/contributing/releases/" %}
+  <div class="font-other-page"><b>See Pull Requests on GitHub:</b></div>
+  <a href="https://github.com/ros-planning/moveit/pulls">
+    {% if page.url == "https://github.com/ros-planning/moveit/pulls" %}
     <div class="row no-gutters">
       <img src="/assets/install_page/current_page_left.png" class="current-page-image-left">
       <img src="/assets/install_page/current_page_right.png" class="current-page-image-right">
       <div class="font-current-page">
         {% else %}
         <div>
-          <div class="row font-other-page">
+          <div class="row font-other-page" style="text-indent: 10px">
             {% endif %}
-            Releases
+	    → MoveIt (ROS 1)
           </div>
         </div>
   </a>
+  <a href="https://github.com/ros-planning/moveit2/pulls">
+    {% if page.url == "https://github.com/ros-planning/moveit2/pulls" %}
+    <div class="row no-gutters">
+      <img src="/assets/install_page/current_page_left.png" class="current-page-image-left">
+      <img src="/assets/install_page/current_page_right.png" class="current-page-image-right">
+      <div class="font-current-page">
+        {% else %}
+        <div>
+          <div class="row font-other-page" style="text-indent: 10px">
+            {% endif %}
+	    → MoveIt (ROS 2)
+          </div>
+        </div>
+  </a>
+  <div class="version-header">
+    Development
+  </div>
   <a href="/documentation/contributing/code/">
     {% if page.url == "/documentation/contributing/code/" %}
     <div class="row no-gutters">
@@ -72,8 +90,8 @@
           </div>
         </div>
   </a>
-  <a href="https://github.com/ros-planning/moveit.ros.org/pulls">
-    {% if page.url == "https://github.com/ros-planning/moveit.ros.org/pulls" %}
+  <a href="/documentation/contributing/releases/">
+    {% if page.url == "/documentation/contributing/releases/" %}
     <div class="row no-gutters">
       <img src="/assets/install_page/current_page_left.png" class="current-page-image-left">
       <img src="/assets/install_page/current_page_right.png" class="current-page-image-right">
@@ -82,8 +100,9 @@
         <div>
           <div class="row font-other-page">
             {% endif %}
-            See Pull Requests on GitHub
+            Releases
           </div>
         </div>
   </a>
+
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -86,7 +86,7 @@
                 <a href="/documentation/contributing/pullrequests/">Pull Requests</a>
               </li>
               <li>
-                <a href="/documentation/contributing/code/">Code Style</a>
+                <a href="/documentation/contributing/code/">Development</a>
               </li>
             </ul>
           </div>

--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -70,7 +70,7 @@
               <a class="dropdown-item" href="/moveit/ros/2019/09/19/moveit-workshop-macau.html">MoveIt Workshop</a>
               <a class="dropdown-item" href="/events/world-moveit-day/2021/01/15/world-moveit-day-2021.html">World MoveIt Day</a>
               <a class="dropdown-item" href="/documentation/contributing/pullrequests/">Pull Requests</a>
-              <a class="dropdown-item" href="/documentation/contributing/code/">Code Style</a>
+              <a class="dropdown-item" href="/documentation/contributing/code/">Development</a>
             </div>
           </li>
           <li class="nav-item">

--- a/_layouts/contribution-guide.html
+++ b/_layouts/contribution-guide.html
@@ -7,7 +7,7 @@
       <div class='row'>
         <div class='col-sm-12'>
           <div class='row no-gutters'>
-            {% include pullrequests-nav.html %}
+            {% include contribution-guide-nav.html %}
             <div class="rectangle-boarder-big col-9 col-sm-9">
               {{ content }}
             </div>

--- a/documentation/contributing/code/index.markdown
+++ b/documentation/contributing/code/index.markdown
@@ -2,7 +2,7 @@
 author: davetcoleman
 comments: true
 date: 2016-8-1 02:13:26+00:00
-layout: pullrequests
+layout: contribution-guide
 slug: code
 title: Style Guidelines
 redirect_from: "/documentation/contributing/code.html"

--- a/documentation/contributing/continuous_integration/index.markdown
+++ b/documentation/contributing/continuous_integration/index.markdown
@@ -2,7 +2,7 @@
 author: davetcoleman
 comments: true
 date: 2016-9-14 02:13:26+00:00
-layout: page
+layout: contribution-guide
 slug: contributing
 title: Continuous Integration
 redirect_from: "/documentation/contributing/continuous_integration.html"

--- a/documentation/contributing/maintainer_pr/index.markdown
+++ b/documentation/contributing/maintainer_pr/index.markdown
@@ -1,6 +1,6 @@
 ---
 author: v4hn
-layout: pullrequests
+layout: contribution-guide
 slug: maintainer_pr
 title: Pull Requests - Maintainer
 ---

--- a/documentation/contributing/pullrequests/index.markdown
+++ b/documentation/contributing/pullrequests/index.markdown
@@ -1,6 +1,6 @@
 ---
 author: v4hn
-layout: pullrequests
+layout: contribution-guide
 slug: pullrequests
 title: Pull Requests
 ---

--- a/documentation/contributing/releases/index.markdown
+++ b/documentation/contributing/releases/index.markdown
@@ -1,6 +1,6 @@
 ---
 author: tylerjw
-layout: pullrequests
+layout: contribution-guide
 slug: releases
 title: Releases
 ---


### PR DESCRIPTION
Doing this in preparation to add more content in the "Development" section. I thought, these nav sections were somehow confusing. Also, I fixed the PR links to point at both MoveIt versions and fixed the CI page layout.

![contributing](https://user-images.githubusercontent.com/4572766/117067038-ce386980-ad29-11eb-8829-45136937741f.png)

