### PR TITLE
Remove redundant wget

### DIFF
--- a/install-moveit2/source/index.markdown
+++ b/install-moveit2/source/index.markdown
@@ -75,9 +75,8 @@ Create a colcon workspace:
 
 Download the repository and install any dependencies:
 
-    wget https://raw.githubusercontent.com/ros-planning/moveit2/main/moveit2.repos
-    vcs import < moveit2.repos
     git clone https://github.com/ros-planning/moveit2.git
+    vcs import < moveit2/moveit2.repos
     rosdep install -r --from-paths . --ignore-src --rosdistro foxy -y
 
 ## Build MoveIt


### PR DESCRIPTION
`wget` statement in moveit2 install docs is redundant and in that case we actually have two moveit2.repos files. This PR removes this redundancy and updates instructions accordingly.