### PR TITLE
Update URL of servo tutorial

### DIFF
--- a/_posts/2020-09-04-moveit2-foxy-release.md
+++ b/_posts/2020-09-04-moveit2-foxy-release.md
@@ -16,7 +16,7 @@ categories:
 
 We are proud to announce the first non-beta release of MoveIt 2, for ROS 2 Foxy Fitzroy. MoveIt 2 Foxy is a major milestone for the MoveIt project as we are now feature complete with MoveIt 1. We believe this achievement will enable the next generation of complex dexterous manipulation applications, beyond the impact it has already had over the past 10 years.
 
-The focus of MoveIt 2 is on realtime performance, particularly provided by ROS 2's native realtime support via DDS. The latest feature on this front is MoveIt Servo a closed-loop, Jacobian-based planner that can avoid collision objects in realtime. The latest version of Servo (previously Jog Arm) uses ROS 2 composable nodes and greatly improved test coverage: see <a href="https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/doc/running_the_demos.md" target="_blank">the MoveIt Servo tutorials</a>.
+The focus of MoveIt 2 is on realtime performance, particularly provided by ROS 2's native realtime support via DDS. The latest feature on this front is MoveIt Servo a closed-loop, Jacobian-based planner that can avoid collision objects in realtime. The latest version of Servo (previously Jog Arm) uses ROS 2 composable nodes and greatly improved test coverage: see <a href="http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html" target="_blank">the MoveIt Servo tutorials</a>.
 
 ![](/assets/images/blog_posts/moveit2_foxy/servo_teleop_demo.gif)
 
@@ -67,7 +67,7 @@ We are also happy to report that MoveIt 2 now builds on <a href="https://github.
 
 ## Getting Started
 
-To jump in, we have prepared several example applications and launch configurations for testing <a href="https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp" target="_blank">MoveItCpp</a>, <a href="https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_move_group" target="_blank">MoveGroup</a> and <a href="https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/doc/running_the_demos.md" target="_blank">MoveIt Servo</a>. Full tutorials are yet to be ported from MoveIt 1, but due to their similarity are still largely applicable. We know it takes forever to get things running if you are new to ROS2, so we’ve prepared an LXD container that provides you with a precompiled MoveIt 2 workspace that allows you to run all demos right away Check out <a href="https://docs.google.com/document/d/15TJ8U9vk6NBaOUkObfPLFdjzut-JsJsb__H-0mbethE/edit#heading=h.jjeryzb28kbj" target="_blank">these instructions</a>.
+To jump in, we have prepared several example applications and launch configurations for testing <a href="https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp" target="_blank">MoveItCpp</a>, <a href="https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_move_group" target="_blank">MoveGroup</a> and <a href="http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html" target="_blank">MoveIt Servo</a>. Full tutorials are yet to be ported from MoveIt 1, but due to their similarity are still largely applicable. We know it takes forever to get things running if you are new to ROS2, so we’ve prepared an LXD container that provides you with a precompiled MoveIt 2 workspace that allows you to run all demos right away Check out <a href="https://docs.google.com/document/d/15TJ8U9vk6NBaOUkObfPLFdjzut-JsJsb__H-0mbethE/edit#heading=h.jjeryzb28kbj" target="_blank">these instructions</a>.
 
 ## Thanks
 

--- a/_posts/2020-09-09-moveit2-servo.md
+++ b/_posts/2020-09-09-moveit2-servo.md
@@ -29,13 +29,13 @@ Pick and place, mobile manipulation, and contact tasks are the kinds of things S
 
 ## Interface Options
 
-Servo can still be run through its C++ API, and this remains a great option for using Servo in your projects. A demonstration of the C++ API in action was included with the ROS 2 effort, and the hope is that you can get MoveIt Servo running within minutes using this demo, similar to the available [moveit_cpp](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp) demonstration included in the Foxy release. See the [Servo demonstration page](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/doc/running_the_demos.md) for details on getting started.
+Servo can still be run through its C++ API, and this remains a great option for using Servo in your projects. A demonstration of the C++ API in action was included with the ROS 2 effort, and the hope is that you can get MoveIt Servo running within minutes using this demo, similar to the available [moveit_cpp](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp) demonstration included in the Foxy release. See the [Servo demonstration page](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html) for details on getting started.
 
 ![](/assets/images/blog_posts/moveit2_servo/Cpp_Interface_Demo.gif)
 
 Servo also makes use of the ROS 2 composable node framework and offers a component that can be run by itself or in a component container with the rest of your project, allowing intra-process communication. The component (named moveit_servo::ServoServer) takes care of all of the run-time details you would need to manage if using the C++ API interface: loading the parameters, setting up the planning scene, and starting Servo.
 
-The example of the component interface shows how to launch Servo as a component, including enabling intra-process communications to avoid unnecessary message copies. See the [demonstrations page](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/doc/running_the_demos.md#Component-Demo) to get started.
+The example of the component interface shows how to launch Servo as a component, including enabling intra-process communications to avoid unnecessary message copies. See the [demonstrations page](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html#Component-Demo) to get started.
 
 ![](/assets/images/blog_posts/moveit2_servo/Servo_Component_Demo.gif)
 
@@ -58,7 +58,7 @@ Also available through the ROS interface for both the C++ API and component:
 - Changing the “control” dimensions to fil
 - Changing the “drift” dimensions to avoid singularities
 
-Additional services for starting and stopping Servo are available with the component method. See the [tutorial page](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/doc/servo_tutorial.md) for a detailed overview of MoveIt Servo.
+Additional services for starting and stopping Servo are available with the component method. See the [tutorial page](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html) for a detailed overview of MoveIt Servo.
 
 Below is a presentation that Adam gave on his Google Summer of Code project:
 <iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/CZikVEoB52w" frameborder="0" allowfullscreen></iframe>

--- a/install-moveit2/lxd/index.markdown
+++ b/install-moveit2/lxd/index.markdown
@@ -88,7 +88,7 @@ and open a bash shell in the running container instance as user `ubuntu` with su
 
 Verify GUI is working by running `glxgears`. In case `glxgears` is not available or the command fails, see the GUI Troubleshooting section below.
 
-Once you are logged in, you will find the precompiled and source ROS2 workspace directory inside `~/ws_ros2`. Now you are ready to start running the demos ([MoveItCpp](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp), [MoveGroup](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_move_group), [MoveIt Servo](https://github.com/ros-planning/moveit2/blob/main/moveit_ros/moveit_servo/doc/running_the_demos.md)) as for instance:
+Once you are logged in, you will find the precompiled and source ROS2 workspace directory inside `~/ws_ros2`. Now you are ready to start running the demos ([MoveItCpp](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp), [MoveGroup](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_move_group), [MoveIt Servo](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html)) as for instance:
 
     ros2 launch run_moveit_cpp run_moveit_cpp.launch.py
 


### PR DESCRIPTION
Update URL of servo tutorial as we moved it from moveit2 to moveit2_tutorials repo

See https://github.com/ros-planning/moveit2/pull/486

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
