### PR TITLE
WIP: change moveit2_tutorials URL for SSL Certificate

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,7 +28,7 @@
             <h4>DOCS</h4>
             <ul>
               <li>
-                <a target="_blank" href="http://moveit2_tutorials.picknik.ai/">Tutorials</a>
+                <a target="_blank" href="https://moveit2-tutorials.picknik.ai/">Tutorials</a>
               </li>
               <li>
                 <a href="/documentation/applications/">Applications</a>

--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -34,11 +34,11 @@
             </div>
           </li>
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="http://moveit2_tutorials.picknik.ai/" id="navbarDropdownDocs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="nav-link dropdown-toggle" href="https://moveit2-tutorials.picknik.ai/" id="navbarDropdownDocs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Docs
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownDocs">
-              <a class="dropdown-item" target="_blank" href="http://moveit2_tutorials.picknik.ai/">Tutorials</a>
+              <a class="dropdown-item" target="_blank" href="https://moveit2-tutorials.picknik.ai/">Tutorials</a>
               <a class="dropdown-item" href="/documentation/applications/">Applications</a>
               <a class="dropdown-item" href="/documentation/concepts/">Concepts</a>
               <a class="dropdown-item" href="/documentation/related_projects/">Related Projects</a>

--- a/_posts/2020-09-04-moveit2-foxy-release.md
+++ b/_posts/2020-09-04-moveit2-foxy-release.md
@@ -16,7 +16,7 @@ categories:
 
 We are proud to announce the first non-beta release of MoveIt 2, for ROS 2 Foxy Fitzroy. MoveIt 2 Foxy is a major milestone for the MoveIt project as we are now feature complete with MoveIt 1. We believe this achievement will enable the next generation of complex dexterous manipulation applications, beyond the impact it has already had over the past 10 years.
 
-The focus of MoveIt 2 is on realtime performance, particularly provided by ROS 2's native realtime support via DDS. The latest feature on this front is MoveIt Servo a closed-loop, Jacobian-based planner that can avoid collision objects in realtime. The latest version of Servo (previously Jog Arm) uses ROS 2 composable nodes and greatly improved test coverage: see <a href="http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html" target="_blank">the MoveIt Servo tutorials</a>.
+The focus of MoveIt 2 is on realtime performance, particularly provided by ROS 2's native realtime support via DDS. The latest feature on this front is MoveIt Servo a closed-loop, Jacobian-based planner that can avoid collision objects in realtime. The latest version of Servo (previously Jog Arm) uses ROS 2 composable nodes and greatly improved test coverage: see <a href="https://moveit2-tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html" target="_blank">the MoveIt Servo tutorials</a>.
 
 ![](/assets/images/blog_posts/moveit2_foxy/servo_teleop_demo.gif)
 
@@ -67,7 +67,7 @@ We are also happy to report that MoveIt 2 now builds on <a href="https://github.
 
 ## Getting Started
 
-To jump in, we have prepared several example applications and launch configurations for testing <a href="https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp" target="_blank">MoveItCpp</a>, <a href="https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_move_group" target="_blank">MoveGroup</a> and <a href="http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html" target="_blank">MoveIt Servo</a>. Full tutorials are yet to be ported from MoveIt 1, but due to their similarity are still largely applicable. We know it takes forever to get things running if you are new to ROS2, so we’ve prepared an LXD container that provides you with a precompiled MoveIt 2 workspace that allows you to run all demos right away Check out <a href="https://docs.google.com/document/d/15TJ8U9vk6NBaOUkObfPLFdjzut-JsJsb__H-0mbethE/edit#heading=h.jjeryzb28kbj" target="_blank">these instructions</a>.
+To jump in, we have prepared several example applications and launch configurations for testing <a href="https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp" target="_blank">MoveItCpp</a>, <a href="https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_move_group" target="_blank">MoveGroup</a> and <a href="https://moveit2-tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html" target="_blank">MoveIt Servo</a>. Full tutorials are yet to be ported from MoveIt 1, but due to their similarity are still largely applicable. We know it takes forever to get things running if you are new to ROS2, so we’ve prepared an LXD container that provides you with a precompiled MoveIt 2 workspace that allows you to run all demos right away Check out <a href="https://docs.google.com/document/d/15TJ8U9vk6NBaOUkObfPLFdjzut-JsJsb__H-0mbethE/edit#heading=h.jjeryzb28kbj" target="_blank">these instructions</a>.
 
 ## Thanks
 

--- a/_posts/2020-09-09-moveit2-servo.md
+++ b/_posts/2020-09-09-moveit2-servo.md
@@ -29,13 +29,13 @@ Pick and place, mobile manipulation, and contact tasks are the kinds of things S
 
 ## Interface Options
 
-Servo can still be run through its C++ API, and this remains a great option for using Servo in your projects. A demonstration of the C++ API in action was included with the ROS 2 effort, and the hope is that you can get MoveIt Servo running within minutes using this demo, similar to the available [moveit_cpp](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp) demonstration included in the Foxy release. See the [Servo demonstration page](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html) for details on getting started.
+Servo can still be run through its C++ API, and this remains a great option for using Servo in your projects. A demonstration of the C++ API in action was included with the ROS 2 effort, and the hope is that you can get MoveIt Servo running within minutes using this demo, similar to the available [moveit_cpp](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp) demonstration included in the Foxy release. See the [Servo demonstration page](https://moveit2-tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html) for details on getting started.
 
 ![](/assets/images/blog_posts/moveit2_servo/Cpp_Interface_Demo.gif)
 
 Servo also makes use of the ROS 2 composable node framework and offers a component that can be run by itself or in a component container with the rest of your project, allowing intra-process communication. The component (named moveit_servo::ServoServer) takes care of all of the run-time details you would need to manage if using the C++ API interface: loading the parameters, setting up the planning scene, and starting Servo.
 
-The example of the component interface shows how to launch Servo as a component, including enabling intra-process communications to avoid unnecessary message copies. See the [demonstrations page](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html#Component-Demo) to get started.
+The example of the component interface shows how to launch Servo as a component, including enabling intra-process communications to avoid unnecessary message copies. See the [demonstrations page](https://moveit2-tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html#Component-Demo) to get started.
 
 ![](/assets/images/blog_posts/moveit2_servo/Servo_Component_Demo.gif)
 
@@ -58,7 +58,7 @@ Also available through the ROS interface for both the C++ API and component:
 - Changing the “control” dimensions to fil
 - Changing the “drift” dimensions to avoid singularities
 
-Additional services for starting and stopping Servo are available with the component method. See the [tutorial page](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html) for a detailed overview of MoveIt Servo.
+Additional services for starting and stopping Servo are available with the component method. See the [tutorial page](https://moveit2-tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html) for a detailed overview of MoveIt Servo.
 
 Below is a presentation that Adam gave on his Google Summer of Code project:
 <iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/CZikVEoB52w" frameborder="0" allowfullscreen></iframe>

--- a/_posts/2021-06-08-moveit-vs-moveit2.md
+++ b/_posts/2021-06-08-moveit-vs-moveit2.md
@@ -86,7 +86,7 @@ With the release of ROS 2 Galactic, we would like to share the new features only
       <td class="done">✓</td>
     </tr>
     <tr>
-      <td><a href="http://moveit2_tutorials.picknik.ai/doc/mobile_base_arm/mobile_base_arm_tutorial.html" target="_blank">Planning for Differential Drive Bases</a></td>
+      <td><a href="https://moveit2-tutorials.picknik.ai/doc/mobile_base_arm/mobile_base_arm_tutorial.html" target="_blank">Planning for Differential Drive Bases</a></td>
       <td class="not">✕</td>
       <td class="done">✓</td>
     </tr>
@@ -133,4 +133,4 @@ As of June 8th 2021, we have an experimental chain of PRs that enable compiling 
 
 We are looking for help from upstream maintainers to release their packages so that MoveIt Galactic can be released. We are also facing challenges relating to pre-release testing of packages and debugging packages failing on the buildfarm. When these two issues are resolved we will have a Galactic and Rolling release.
 
-There has been a lot of recent progress in porting the [tutorials](http://moveit2_tutorials.picknik.ai) to MoveIt 2. We look forward to the official release of MoveIt 2 Galactic on June 30th!
+There has been a lot of recent progress in porting the [tutorials](https://moveit2-tutorials.picknik.ai) to MoveIt 2. We look forward to the official release of MoveIt 2 Galactic on June 30th!

--- a/_posts/2021-07-08-moveit-galactic.md
+++ b/_posts/2021-07-08-moveit-galactic.md
@@ -27,7 +27,7 @@ With MoveIt’s latest version bump to 2.2.0 we’ve finally added support for r
 
 For now, all distros are supported from the [main](https://github.com/ros-planning/moveit2/tree/main) branch. In the future, main will run Rolling, support for older distros - like Foxy now - will be continued in separate maintenance branches.
 
-The release is currently only available as source install as we are still working on some issues with the build farm. For getting started, check out the [install instructions](https://moveit.ros.org/install-moveit2/source/) and the [tutorials](http://moveit2_tutorials.picknik.ai/).
+The release is currently only available as source install as we are still working on some issues with the build farm. For getting started, check out the [install instructions](https://moveit.ros.org/install-moveit2/source/) and the [tutorials](https://moveit2-tutorials.picknik.ai/).
 
 ### What's next...
 You can always find out more about what features and fixes are in the next version of MoveIt on the [MoveIt Roadmap](https://moveit.ros.org/documentation/contributing/roadmap/) along with long term goals and sprint plans.

--- a/documentation/applications/index.markdown
+++ b/documentation/applications/index.markdown
@@ -9,7 +9,7 @@ title: Applications
 
 # MoveIt Applications
 
-There are many diverse application examples of what you can use MoveIt for. The list below demonstrates some of the advanced applications developed on MoveIt. You can have fun by trying the applications, which may help you figure out how to fit different features together. If you are interested, you can visit [MoveIt Tutorials](http://moveit2_tutorials.picknik.ai/) for further technical details. At the same time, your contribution is encouraged, no matter the application is developed for some usages, competitions or research topics, or to demonstrate the newly developed MoveIt feature.
+There are many diverse application examples of what you can use MoveIt for. The list below demonstrates some of the advanced applications developed on MoveIt. You can have fun by trying the applications, which may help you figure out how to fit different features together. If you are interested, you can visit [MoveIt Tutorials](https://moveit2-tutorials.picknik.ai/) for further technical details. At the same time, your contribution is encouraged, no matter the application is developed for some usages, competitions or research topics, or to demonstrate the newly developed MoveIt feature.
 
 ## MoveIt Example Apps
 

--- a/documentation/concepts/index.markdown
+++ b/documentation/concepts/index.markdown
@@ -9,7 +9,7 @@ title: Concepts
 
 # Concepts
 
-The following is an overview of how MoveIt works. For more concrete documentation and details see the [tutorials](http://moveit2_tutorials.picknik.ai/) or the [developers' concepts](/documentation/concepts/developer_concepts/).
+The following is an overview of how MoveIt works. For more concrete documentation and details see the [tutorials](https://moveit2-tutorials.picknik.ai/) or the [developers' concepts](/documentation/concepts/developer_concepts/).
 
 ## System Architecture
 
@@ -30,7 +30,7 @@ The users can access the actions and services provided by _move_group_ in three 
 
 - **In Python** - using the [moveit_commander](http://docs.ros.org/noetic/api/moveit_commander/html/classmoveit__commander_1_1move__group_1_1MoveGroupCommander.html) package
 
-- **Through a GUI** - using the [Motion Planning plugin to Rviz](http://moveit2_tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html) (the ROS visualizer)
+- **Through a GUI** - using the [Motion Planning plugin to Rviz](https://moveit2-tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html) (the ROS visualizer)
 
 _move_group_ can be configured using the ROS param server from where it will also get the URDF and SRDF for the robot.
 
@@ -177,7 +177,7 @@ MoveIt uses a plugin infrastructure, especially targeted towards allowing users 
 
 ### **IKFast Plugin**
 
-Often, users may choose to implement their own kinematics solvers, e.g. the PR2 has its own kinematics solvers. A popular approach to implementing such a solver is using the [IKFast package](http://moveit2_tutorials.picknik.ai/doc/ikfast/ikfast_tutorial.html) to generate the C++ code needed to work with your particular robot.
+Often, users may choose to implement their own kinematics solvers, e.g. the PR2 has its own kinematics solvers. A popular approach to implementing such a solver is using the [IKFast package](https://moveit2-tutorials.picknik.ai/doc/ikfast/ikfast_tutorial.html) to generate the C++ code needed to work with your particular robot.
 
 ---
 

--- a/documentation/faqs/index.markdown
+++ b/documentation/faqs/index.markdown
@@ -15,7 +15,7 @@ title: FAQs
 
 _I'm totally new, how do I get started?_
 
-  * See the [tutorials](http://moveit2_tutorials.picknik.ai/) &#128540;
+  * See the [tutorials](https://moveit2-tutorials.picknik.ai/) &#128540;
 
 _What version of MoveIt should I use?_
 

--- a/index.markdown
+++ b/index.markdown
@@ -44,7 +44,7 @@ redirect_from: '/moveit/'
                                 Watch overview
                                 </button>
                                 <a class="button button-yellow modal-link" href="https://www.youtube-nocookie.com/embed/7KvF7Dj7bz0" target="_blank">Watch overview</a>
-                                <a class="button button-transparent" href="http://moveit2_tutorials.picknik.ai/" target="_blank">Get Started</a>
+                                <a class="button button-transparent" href="https://moveit2-tutorials.picknik.ai/" target="_blank">Get Started</a>
                             </div>
                         </div>
                     </div>

--- a/install-moveit2/binary/index.markdown
+++ b/install-moveit2/binary/index.markdown
@@ -79,7 +79,7 @@ title: MoveIt 2 Binary Install
         <p>
           Start planning in Rviz with:
         </p>
-        <a href="http://moveit2_tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html" target="_blank">
+        <a href="https://moveit2-tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html" target="_blank">
           <span class="link-with-background">
             MoveIt 2 Getting Started Tutorial
           </span>
@@ -113,7 +113,7 @@ title: MoveIt 2 Binary Install
         <p>
           Start planning in Rviz with:
         </p>
-        <a href="http://moveit2_tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html" target="_blank">
+        <a href="https://moveit2-tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html" target="_blank">
           <span class="link-with-background">
             MoveIt 2 Getting Started Tutorial
           </span>
@@ -147,7 +147,7 @@ title: MoveIt 2 Binary Install
         <p>
           Start planning in Rviz with:
         </p>
-        <a href="http://moveit2_tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html" target="_blank">
+        <a href="https://moveit2-tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html" target="_blank">
           <span class="link-with-background">
             MoveIt 2 Getting Started Tutorial
           </span>

--- a/install-moveit2/lxd/index.markdown
+++ b/install-moveit2/lxd/index.markdown
@@ -88,7 +88,7 @@ and open a bash shell in the running container instance as user `ubuntu` with su
 
 Verify GUI is working by running `glxgears`. In case `glxgears` is not available or the command fails, see the GUI Troubleshooting section below.
 
-Once you are logged in, you will find the precompiled and source ROS2 workspace directory inside `~/ws_ros2`. Now you are ready to start running the demos ([MoveItCpp](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp), [MoveGroup](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_move_group), [MoveIt Servo](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html)) as for instance:
+Once you are logged in, you will find the precompiled and source ROS2 workspace directory inside `~/ws_ros2`. Now you are ready to start running the demos ([MoveItCpp](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_moveit_cpp), [MoveGroup](https://github.com/ros-planning/moveit2/tree/main/moveit_demo_nodes/run_move_group), [MoveIt Servo](https://moveit2-tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html)) as for instance:
 
     ros2 launch run_moveit_cpp run_moveit_cpp.launch.py
 

--- a/install-moveit2/source/index.markdown
+++ b/install-moveit2/source/index.markdown
@@ -109,7 +109,7 @@ Setup your environment - you can do this every time you work with this particula
 
 Check out the MoveIt 2 Tutorials on how to get started with simple demo packages.
 
-<a href="http://moveit2_tutorials.picknik.ai/" target="_blank">
+<a href="https://moveit2-tutorials.picknik.ai/" target="_blank">
   <span class="link-with-background">
     MoveIt 2 Tutorials
   </span>


### PR DESCRIPTION
# Do Not Merge Yet

### Description

Github cannot provide a certificate for URLs with `_` in them. Thus, `moveit2_tutorials` was changes to `moveit2-tutorials`.

As part of this I also created a redirect page so any old links will still work

### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
