### PR TITLE
Fix installation by importing repos from moveit2_$ROS_DISTRO.repos

### DIFF
--- a/install-moveit2/source/index.markdown
+++ b/install-moveit2/source/index.markdown
@@ -87,7 +87,7 @@ Download the repository and install any dependencies. Issue the relevant command
 ### Galactic and Rolling
 
     git clone https://github.com/ros-planning/moveit2.git -b main
-    vcs import < moveit2/moveit2.repos
+    for repo in moveit2/moveit2.repos $(f="moveit2/moveit2_$ROS_DISTRO.repos"; test -r $f && echo $f); do vcs import < "$repo"; done
     rosdep install -r --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
 
 ## Build MoveIt


### PR DESCRIPTION
### Description

We have two .repos files, a common one and the other one is distro-specific, this PR makes it so we import from both

### Checklist
- [ ] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
