### PR TITLE
Fix broken ikfast tutorial link

### DIFF
--- a/documentation/concepts/index.markdown
+++ b/documentation/concepts/index.markdown
@@ -177,7 +177,7 @@ MoveIt uses a plugin infrastructure, especially targeted towards allowing users 
 
 ### **IKFast Plugin**
 
-Often, users may choose to implement their own kinematics solvers, e.g. the PR2 has its own kinematics solvers. A popular approach to implementing such a solver is using the [IKFast package](http://moveit2_tutorials.picknik.ai/doc/ikfast/ikfast_tutorial.html) to generate the C++ code needed to work with your particular robot.
+Often, users may choose to implement their own kinematics solvers, e.g. the PR2 has its own kinematics solvers. A popular approach to implementing such a solver is using the [IKFast package](https://ros-planning.github.io/moveit_tutorials/doc/ikfast/ikfast_tutorial.html) to generate the C++ code needed to work with your particular robot.
 
 ---
 


### PR DESCRIPTION
CI is complaining about a broken link for IKFast that is indeed removed from ROS2 tutorial page. This PR changes it so it points to ROS1 tutorial page instead. This shouldn't be a problem since that tutorial is not ported to ROS2 yet. We should change the link to point ROS2 version when this is ported.