### PR TITLE
Update note about C++ standard

### DIFF
--- a/documentation/contributing/code/index.markdown
+++ b/documentation/contributing/code/index.markdown
@@ -18,7 +18,7 @@ In addition MoveIt has some extra style preferences:
 
 ## C++
 
- - We use C++14
+ - We use C++17
  - Use the C++ standard library (``std::``) whenever possible
  - Avoid C-style functions such as ``FLT_EPSILON`` - instead use ``std::numeric_limits<double>::epsilon()``
  - Boost is an encouraged library when functionality is not available in the standard library


### PR DESCRIPTION
C++17 is now the default: https://github.com/ros-planning/moveit2/blob/e3d4768541602fca900dacff50aac6374853472d/moveit_common/cmake/moveit_package.cmake#L36
