### PR TITLE
Update release schedule to link to ZenHub

### DIFF
--- a/documentation/contributing/releases/index.markdown
+++ b/documentation/contributing/releases/index.markdown
@@ -13,15 +13,7 @@ This 6 week pace is a balance between releasing new improvements quickly and pre
 
 ## Upcoming releases
 
-The release schedule is shown here:
-
-<iframe src="https://calendar.google.com/calendar/embed?src=c_bpueq5jcajuaejr2di0hdr4qgg%40group.calendar.google.com&ctz=America%2FDenver" width="100%" height="350px" title="MoveIt release calendar"></iframe>
-
-### Typical Release Schedule
-
-* Friday: Begin preparing release
-* Following Friday: Bloom
-* Tuesday After Bloom: Public Announcement
+Releases for MoveIt are planned using the ZenHub Roadmap.  You can follow our [detailed Roadmap here](https://app.zenhub.com/workspaces/moveit-61675936b391800012280f6d/roadmap).
 
 ## Permissions
 

--- a/documentation/contributing/roadmap/index.markdown
+++ b/documentation/contributing/roadmap/index.markdown
@@ -18,7 +18,7 @@ title: MoveIt Roadmap
   </div>
 </div>
 <div class="row current-version roadmap-current-version">
-    <a class="button button-transparent button-transparent__blue" href="/documentation/contributing/releases/">See Every 6 Week Release Schedule</a>
+    <a class="button button-transparent button-transparent__blue" href="https://app.zenhub.com/workspaces/moveit-61675936b391800012280f6d/roadmap">Detailed Roadmap on ZenHub</a>
 
     <!-- Release progress bar -->
     {% include release-progress.html %}


### PR DESCRIPTION
### Description

This updates the Release Schedule section to reference ZenHub where we are currently planning releases.

### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
