### PR TITLE
Clarify, improve, and slightly modify various maintainer policies

### DIFF
--- a/_posts/2021-12-17-sprint-report-3.md
+++ b/_posts/2021-12-17-sprint-report-3.md
@@ -29,13 +29,13 @@ We have just finished our third MoveIt sprint using ZenHub for planning and woul
 
 ### MoveIt 2
 
-In this sprint, we landed the port of the [Pilz Industrial Motion Planner](https://moveit.picknik.ai/main/doc/pilz_industrial_motion_planner/pilz_industrial_motion_planner.html?highlight=pilz) into MoveIt 2.
+In this sprint, we landed the port of the [Pilz Industrial Motion Planner](https://moveit.picknik.ai/main/doc/examples/pilz_industrial_motion_planner/pilz_industrial_motion_planner.html?highlight=pilz) into MoveIt 2.
 
 The merge of this introduced a circular dependency we are working on resolving before we can release for Galactic and Rolling.
 There are two approaches in PRs and we are working out which approach will work best.
 [henningkayser](https://github.com/henningkayser) did this port over the last few sprints and was especially careful to make sure many of the tests were ported and working before we merged it.
 
-In this sprint, we also landed the [Hybrid Planner](https://moveit.picknik.ai/main/doc/hybrid_planning/hybrid_planning_tutorial.html) into MoveIt 2 which was the project of [sjahr](https://github.com/sjahr) this last summer.
+In this sprint, we also landed the [Hybrid Planner](https://moveit.picknik.ai/main/doc/examples/hybrid_planning/hybrid_planning_tutorial.html) into MoveIt 2 which was the project of [sjahr](https://github.com/sjahr) this last summer.
 [AndyZe](https://github.com/AndyZe) lead the effort to get it finished so it can be merged.
 
 We look forward to releasing both of these into Galactic and Rolling.

--- a/about/maintainer_policy/index.markdown
+++ b/about/maintainer_policy/index.markdown
@@ -19,6 +19,7 @@ In addition to gratitude, some advantages of being a MoveIt maintainer / core co
  - Be listed on the MoveIt website
  - Networking opportunities: gain reputation in the largest robotics community on earth
  - Quicker code contributions: you only need one review to get your code merged in, while non-maintainer/non-core contributor pull requests require two approvals.
+ - Free MoveIt T-Shirt from PickNik Robotics
 
 ## Core Contributors
 
@@ -31,7 +32,9 @@ We also ask you have completed at minimum the following:
 
  - 2 substantial pull requests merged
  - 4 pull requests reviewed via the "Approve" or "Request Changes" button
- - 1 maintainer meeting attended
+ - 2 maintainer meetings attended
+
+If you feel like you qualify to be a core contributor please reach out to any of the [MoveIt Maintainers](https://moveit.ros.org/about/) and we'd be happy to discuss and get you added!
 
 ## Maintainers
 
@@ -47,8 +50,8 @@ We've formalized the process here to disambiguate when someone should be added.
 We hope it's not too intimidating as we want to add as many qualified Maintainers as possible.
 To qualify for being added to the group you must:
 
- - Have proven a good understanding of fundamental parts of the MoveIt code base
- - Have completed at least the minimum requirements for Core Contributors, above
+ - Have proven a decent understanding of fundamental parts of the MoveIt code base
+ - Have completed at least double of the minimum requirements for Core Contributors, above
  - Be willing to help review on average 1 pull request a week or more
  - Read the MoveIt pull request guidelines to understand our policies
 
@@ -84,10 +87,12 @@ In the [ros-planning](https://github.com/ros-planning/) Github organization, the
 
 These projects are run entirely by different teams, maintainer policies, etc.
 Write access between these two projects is isolated via usage of different Github Org Teams.
-In addition, MoveIt has a secondary Github team for non-write access. The ros-planning org currently has three total teams:
+In addition, MoveIt has a secondary Github team for non-write access. The ros-planning org currently has four total teams:
 
  - Navigation Maintainers
    - Has write access to all navigation-related packages
+ - MoveIt Admin
+   - Has write access to all MoveIt-related packages & admin access to all repos settings
  - MoveIt Maintainers
    - Has write access to all MoveIt-related packages
  - MoveIt Contributors

--- a/documentation/contributing/maintainer_pr/index.markdown
+++ b/documentation/contributing/maintainer_pr/index.markdown
@@ -5,61 +5,76 @@ slug: maintainer_pr
 title: Pull Requests - Maintainer
 ---
 
-# Handling Pull Requests
+# Maintainer Policies on Handling Pull Requests
 
 MoveIt is a huge project with multiple maintainers and many contributing users.
 Thus, sometimes it becomes quite hard to keep track of all open requests and their current state.
-To ease the process of getting your contribution merged into the project, the following provides a guideline for maintainers.
+To ease the process of getting contributions merged into the project quickly, the following provides a guideline for maintainers.
 
-## Maintainer Side
+## Branches Policy
 
-The ``*-devel`` branches of the repositories must always compile on the target platforms.
+Our development branches are called ``main`` (MoveIt 2) and ``master`` (MoveIt 1). We also have important distribution-specific release branches, named ``*-devel`` (MoveIt 1) or just e.g. ``foxy`` (MoveIt 2).
 
-The ``*-devel`` branches must not be force-pushed.
+## No Direct Commits or Force Pushes
 
-### No Direct Commits
+No one is allowed to directly commit or force push to the development or distribution branches of the repositories. This should already be disabled in the Github repo settings.
 
-No one is allowed to directly commit to the ``*-devel`` branches of the repositories. Instead they should create feature branches and add pull-requests.
-The only commits that might be pushed directly are cherry-picks from older branches (see below) and administrative changes (e.g. CHANGELOGS, tags).
+The only commits that might be pushed directly are cherry-picks from older branches (see below) and administrative changes (e.g. CHANGELOGS, tags). However with Mergify bot this should be discouraged also.
 
-### Typically, two "Approves" == Merge
+## Feature Branches in Upstream Repositories
 
-If you see a trustworthy approval review in a request or the requestor is a fellow maintainer and all feedback has been addressed by the requestor,
-merge the request after your own review. Otherwise submit an "Approval" review after you are satisfied after the review.
+Pull requests should originate from a user's fork of the main MoveIt upstream repositories as much as possible. Github has a feature that allows a MoveIt maintainer to contribute to a contributor's pull request branch [even if the branch is on another user's fork](https://help.github.com/articles/committing-changes-to-a-pull-request-branch-created-from-a-fork/) (Note: as long as its a private Github account and not a Github organization). Use of this is encouraged.
 
-For small or trivial fixes, a single review is sufficient. Additionally, for the ``moveit_experimental`` package, a single review is sufficient.
+### Exceptions to Feature Branches in Upstream Repos
 
-### GitHub Merge Policies
+In rare cases, if a maintainer expects support in the development of a patch from non-maintainer users, they are free to create a new branch in the upstream repository instead. This enables other maintainers to directly push changes there and enables users to add pull-requests targeting the feature branch. To keep the list of branches clear and unambiguous, **names for such branches should always follow the pattern ``pr-<ros distribution>-<keyword description>``**. This makes it clear these branches are not relevant to users not involved in the respective request.
 
-GitHub provides [several merge policies ](https://help.github.com/articles/about-merge-methods-on-github). To avoid clutter in our commit history, usually pull requests should be `squash-merged` (github supports this via a drop-down list on the "merge" button), particularly if there are only single commits or several "fixup commits".
+## Pull Request Approval Policy
+
+No one should ever merge their own PR into a MoveIt repo without a review. This should be enforced in the Github repository settings.
+
+We typically follow a **two approval requirement**. Two reviewers must approve a change using the "Approval" button, with at least one being a MoveIt maintainer.
+
+### Exceptions to Two Approval Policy
+
+MoveIt Maintainers only need need one other review if the following criteria are met:
+- The review is from another maintainer
+- The change is not too large or controversial
+- All feedback has been addressed by the requestor
+
+Once this criteria is met, the maintainer who is the original author is free to merge their own PR in.
+
+Other exceptions for only one approval required:
+- A very small or trivial fix
+- Changes to ``moveit_experimental`` and ``moveit_tutorials`` packages
+
+## GitHub Merge Policies & Best Practices
+
+GitHub provides [several merge policies ](https://help.github.com/articles/about-merge-methods-on-github). To avoid clutter in our commit history, **usually pull requests should be `squash-merged`** (Github supports this via a drop-down list on the "Merge" button), particularly if there are only single commits or several "fixup commits".
 
 However, for larger changes to the code, it's absolutely desired to organize the pull request into multiple, clearly separated, but interrelated commits. In such cases, it is usually also meaningful to keep this commit history, thus being able to track these individual commits also later in the future. In this case, a maintainer should ask the contributor to cleanup "fixup" commits via squashing or interactive rebasing before eventually performing a proper `merge commit`.
 
 Multiple, independent commits should not show up in a single PR, but should be split into multiple independent PRs. GitHub's `rebase-merge` policy, which could be used in such cases, unfortunately drops any notion of the related pull request id. To summarize:
 
-- single commits -> squash
-- multiple fixup-style commits -> squash
-- multiple **clean**, interrelated commits -> merge commit
-- multiple **clean**, independent commits -> rebase and merge
+- Single commits -> squash
+- Multiple fixup-style commits -> squash
+- Multiple **clean**, interrelated commits -> merge commit
+- Multiple **clean**, independent commits -> rebase and merge
 
 Contributors should indicate their desired merge-policy in the main PR comment.
 
-### Feature Branches in Upstream Repositories
-
-Pull requests should originate from a user's fork of the main MoveIt upstream repository as much as possible. Github has a feature that allows a MoveIt maintainer to contribute to a contributor's pull request branch [even if the branch is on another user's fork](https://help.github.com/articles/committing-changes-to-a-pull-request-branch-created-from-a-fork/). Use of this is encouraged.
-
-In rare cases, if a maintainer expects support in the development of a patch from non-maintainer users, they are free to create a new branch in the upstream repository instead. This enables other maintainers to directly push changes there and enables users to add pull-requests targeting the feature branch. To keep the list of branches clear and unambiguous, **names for such branches should always follow the pattern ``pr-<ros distribution>-<keyword description>``**. This makes it clear these branches are not relevant to users not involved in the respective request.
-
-### The Latest Branch Preserves All Original Commits
+## The Latest Branch Preserves All Original Commits
 
 All contributions that get merged into MoveIt and should be included in later ROS distributions have to end up in the latest branch with their full description and individual commits.
 This is necessary in order to preserve the history of the changes.
 Future versions of MoveIt might not share the whole history of older branches and finding your `git blame` returns a commit called ``cherry-picked #123``, without an additional description, is not desirable.
 
-### Merge Only If You Make Sure It Becomes Available In Later Branches Too
+## Merge Only If You Make Sure It Becomes Available In Later Branches Too
 
 Don't merge a request unless you make sure the same (or a similar) patch-set is merged into all later branches at the same time.
 We don't want to lose changes that are available in one ROS distribution because someone forgot to do that.
+
+We use [`mergify`](https://docs.mergify.com) to automize backporting. Just add the corresponding label, e.g. `backport-foxy` to trigger a backport to Foxy.
 
 If the commits apply cleanly to future branches and there is no evidence that they will break anything there, you are free to add the changes to the respective branches.
 (Make sure you respect the all-commits-in-latest-branch guideline though).
@@ -67,3 +82,7 @@ If the commits apply cleanly to future branches and there is no evidence that th
 Otherwise either the requestor or the maintainer should create new pull-requests targeting the later branches.
 If possible, merge these *together* with the original request.
 In this context it might be worth spending some time on making use of features available in later ROS distributions to simplify the code, e.g. by using a new coding standard or a more current version of a library.
+
+## Summary
+
+Thanks for your help maintaining MoveIt, you make things awesome!


### PR DESCRIPTION
Feedback very much welcomed from all MoveIt maintainers. These changes are based on discussions I've had with the MoveIt maintainers from PickNik, and I think are already kinda the de facto rules:

**Core Contributors**
- Publicly offer a free shirt for becoming one
- Increase requirement from 1 maintainer meeting to 2
- Give more direction on how to become one

**MoveIt Maintainers**
- Specify you need **double** the min requirements of a CC
- Change from "good understanding" to "decent understanding" since no one really understands all of MoveIt, of the current maintainers

**Better Document the Github Org Structure**

**Maintainer Merge Policies**
- Update development branches to include new MoveIt 2 naming scheme
- Greatly cleanup section headings and info organization
- Mention Mergify as a new option for cherry picking between branches
- Better clarify when only 1 review is required
- Better clarify when a maintainer can click merge for their own PR
- Add Summary thanking maintainers for what they do

Please don't nit-pick this PR to death if you don't see issues with the overall statements being made. Instead just make a follow up PR to do further cleanup. Much of the info as-is is out of date.