### PR TITLE
binary package name wrong

### DIFF
--- a/install-moveit2/binary/index.markdown
+++ b/install-moveit2/binary/index.markdown
@@ -137,7 +137,7 @@ title: MoveIt 2 Binary Install
         <h3>
           ROS 2 Rolling
           <div class="bash-command">
-            <code>sudo apt install ros-rolling-moveit</code>
+            <code>sudo apt install ros-rolling-moveit-ros</code>
           </div>
         </h3>
         <div class="horizontal-line"></div>


### PR DESCRIPTION
change: ros-rolling-moveit -> ros-rolling-moveit-ros

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
