### PR TITLE
make gsoc announcement more prominent, add PR instructions

### DIFF
--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -24,8 +24,8 @@
         background-color: #27282e;
         color: #fff;
         border-radius: 16px;
-        font-size: 12px;
-        padding: 2px;
+        font-size: 16px;
+        padding: 10px;
         margin-bottom: 20px;
         text-align: left;
         overflow: hidden;

--- a/events/2022-google-summer-of-code/index.markdown
+++ b/events/2022-google-summer-of-code/index.markdown
@@ -85,6 +85,7 @@ MoveIt is planning to participate again in the [Google Summer of Code](https://s
 
 ## Tips for writing a successful Google Summer of Code application for MoveIt
 
+* **Create at least one pull request in a MoveIt-related repository and include a reference to this pull request in your application.**
 * Be specific in describing your experience. Rather than saying "experienced C++ programmer," point us to code that you have written and contributed.
 * Describe your background and experience in robotics and ROS.
 * Tell us what you hope to get out of the Summer of Code experience.


### PR DESCRIPTION
### Description

* Make the Google Summer of Code announcement more prominent on the front page. Renderings at different browser window sizes are shown below.
* Add instructions for applicants to create a MoveIt-related PR.
 
### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
<img width="1295" alt="Screen Shot 2022-03-25 at 5 38 45 PM" src="https://user-images.githubusercontent.com/2381200/160222707-d3c3f1fa-1ebf-402e-bc68-dfa39ce6ddcc.png">
<img width="1084" alt="Screen Shot 2022-03-25 at 5 38 56 PM" src="https://user-images.githubusercontent.com/2381200/160222708-28ec79a3-7582-4ade-a8b1-e7a8628398fb.png">
<img width="855" alt="Screen Shot 2022-03-25 at 5 39 05 PM" src="https://user-images.githubusercontent.com/2381200/160222718-4ef9a11f-951e-4ea9-915f-05530b1de496.png">

