### PR TITLE
changed page to post

### DIFF
--- a/_posts/2022-05-20-gsoc-students.md
+++ b/_posts/2022-05-20-gsoc-students.md
@@ -2,7 +2,7 @@
 author: Mark Moll
 comments: false
 date: 2022-05-20 00:00:00 -0700
-layout: page
+layout: post
 slug: 2022-google-summer-of-code-students
 title: 2022 Google Summer of Code Students
 media_type: image


### PR DESCRIPTION
### Description

The Gsoc post was titled as a page, and is now a post,  let me know if this breaks anything elsewhere, but I didn't see it when I ran locally

### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
