### PR TITLE
Fix CI: stick to html-proofer 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 ruby '2.7.0'
 
 gem 'github-pages'
-gem 'html-proofer'
+gem 'html-proofer', '~> 3.19.4'
 gem 'rubyzip', '~> 2.3.0'


### PR DESCRIPTION
Should Fix CI as in https://github.com/ros-planning/moveit_tutorials/pull/718