### PR TITLE
Fix gif not rendering in servo post

### DIFF
--- a/_posts/2022-07-22-servo-kinematics.md
+++ b/_posts/2022-07-22-servo-kinematics.md
@@ -5,7 +5,7 @@ date: 2022-07-22 00:00:00 -0600
 layout: post
 slug: MoveIt-Servo-Inverse-Kinematics
 title: MoveIt Servo Inverse Kinematics Improvements
-media_type: gif
+media_type: image
 media_link: /assets/images/blog_posts/ee_swirl.gif
 description: Inverse kinematics has been overhauled in MoveIt Servo
 


### PR DESCRIPTION
### Description

The default image is showing in the recent servo IK blog post -- this fix should render the included gif properly.

### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
