### PR TITLE
Update index.markdown

### DIFF
--- a/install-moveit2/source/index.markdown
+++ b/install-moveit2/source/index.markdown
@@ -80,6 +80,7 @@ Create a colcon workspace:
     mkdir -p $COLCON_WS/src
     cd $COLCON_WS/src
 
+You might want to add `export COLCON_WS=~/ws_moveit2/` to your `.bashrc` file.
 ## Download Source Code
 
 Download the repository and install any dependencies. Issue the relevant commands for your ROS distribution.
@@ -116,7 +117,7 @@ Configure and build the workspace:
 
 ### Source the Colcon Workspace
 
-Setup your environment - you can do this every time you work with this particular source install of the code, or you can add this to your ``.bashrc`` (recommended):
+Setup your environment - you can do this every time you work with this particular source install of the code, or you can add this to your ``.bashrc`` (recommended) using `echo $COLCON_WS/install/setup.bash >> ~/.bashrc` :
 
     source $COLCON_WS/install/setup.bash
 


### PR DESCRIPTION
### Description

Ensuring correct path for $COLCON_WS/install/setup.bash in ~/.bashrc for automatic sourcing. This prevents the mistake of directly copying and pasting "$COLCON_WS/install/setup.bash" in ~/.bashrc; the environment variable "$COLCON_WS" would not be present next time & the setup.bash script won't load on startup. 
1. Either, export the variable "$COLCON_WS" to the .bashrc
2. Or, prevent manual copying & pasting by using echo command.

### Checklist
- [x] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
