### PR TITLE
add post for GSoC 2023 participants

### DIFF
--- a/_posts/2023-05-03-google-summer-of-code-participants.md
+++ b/_posts/2023-05-03-google-summer-of-code-participants.md
@@ -1,0 +1,18 @@
+---
+author: Mark Moll
+comments: false
+date: 2023-05-03
+layout: post
+title: "MoveIt's Google Summer of Code 2023 Participants"
+media_type: image
+media_link: /assets/images/blog_posts/Google_Summer_of_Code_sun_logo.png
+description: MoveIt's GSoC 2023 participants have been selected!
+categories:
+- MoveIt 2
+- ROS
+---
+The MoveIt project is excited to announce that MoveIt was awarded 2 slots for the [Google Summer of Code](https://summerofcode.withgoogle.com/) (GSoC) program. GSoC is an international program in which Google awards stipends to people who complete a free and open-source software coding project during the summer. Below are the students and projects selected for 2023.
+
+[V Mohammed Ibrahim](https://www.linkedin.com/in/ibrahiminfinite/) ([Github](https://github.com/ibrahiminfinite)) is a robotics software engineer. He will be working on improved realtime control with MoveIt Servo. He will be mentored by Andy Zelenak and Sebastian Castro.
+
+[Mohamed Raessa](https://www.linkedin.com/in/mohraessa/) ([Github](https://github.com/Robotawi)) is a robotics R&D engineer with Avatarin inc. He has a Ph.D. in robotic manipulation from Osaka University, Japan. His project is focused on  improvements to the `pick_ik` solver. He will _also_ be mentored by Andy Zelenak and Sebastian Castro.

--- a/_posts/2023-05-03-google-summer-of-code-participants.md
+++ b/_posts/2023-05-03-google-summer-of-code-participants.md
@@ -15,4 +15,4 @@ The MoveIt project is excited to announce that MoveIt was awarded 2 slots for th
 
 [V Mohammed Ibrahim](https://www.linkedin.com/in/ibrahiminfinite/) ([Github](https://github.com/ibrahiminfinite)) is a robotics software engineer. He will be working on improved realtime control with MoveIt Servo. He will be mentored by Andy Zelenak and Sebastian Castro.
 
-[Mohamed Raessa](https://www.linkedin.com/in/mohraessa/) ([Github](https://github.com/Robotawi)) is a robotics R&D engineer with Avatarin inc. He has a Ph.D. in robotic manipulation from Osaka University, Japan. His project is focused on  improvements to the `pick_ik` solver. He will _also_ be mentored by Andy Zelenak and Sebastian Castro.
+[Mohamed Raessa](https://www.linkedin.com/in/mohraessa/) ([Github](https://github.com/Robotawi)) is a robotics R&D engineer with Avatarin inc. He has a Ph.D. in robotic manipulation from Osaka University, Japan. His project is focused on  improvements to the `pick_ik` solver. He will be mentored by Sebastian Castro and Stephanie Eng.


### PR DESCRIPTION
### Description

Blog post announcing the participants selected for GSoC 2023.

### Checklist
- [X] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
