### PR TITLE
Advertise our binary install

### DIFF
--- a/_posts/2021-06-08-moveit-vs-moveit2.md
+++ b/_posts/2021-06-08-moveit-vs-moveit2.md
@@ -86,7 +86,7 @@ With the release of ROS 2 Galactic, we would like to share the new features only
       <td class="done">✓</td>
     </tr>
     <tr>
-      <td><a href="https://github.com/hello-robot/stretch_ros2/tree/ros_world2021#whole_body_planning" target="_blank">Planning for Differential Drive Bases</a></td>
+      <td><a href="https://github.com/AndyZe/stretch_ros2/tree/ros_world2021#guided-exploration-pick-and-place-with-whole-body-planning" target="_blank">Planning for Differential Drive Bases</a></td>
       <td class="not">✕</td>
       <td class="done">✓</td>
     </tr>

--- a/_posts/2021-10-29-rosworld-moveit-workshop.md
+++ b/_posts/2021-10-29-rosworld-moveit-workshop.md
@@ -19,7 +19,7 @@ Below are some videos demos of the code that the participants played around with
 
 * A demonstration of the MoveIt motion planning panel in RViz:<br>
   <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/MwDs_uX6SKw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-* A basic pick & place demo [[code]](https://github.com/hello-robot/stretch_ros2/blob/ros_world2021/stretch_roscon_demos/src/move_group_interface_demo.cpp):<br>
+* A basic pick & place demo [[code]](https://github.com/hello-robot/AndyZe/blob/ros_world2021/stretch_roscon_demos/src/move_group_interface_demo.cpp):<br>
   <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/auazxjtOjsY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 * An advanced pick & place demo using the MoveIt Task Constructor [[code]](https://github.com/PickNikRobotics/stretch_moveit_plugins/tree/main/pick_place_task):<br>
   <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Tm93GFlT234" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/events/rosworld-2021-workshop/index.markdown
+++ b/events/rosworld-2021-workshop/index.markdown
@@ -78,21 +78,21 @@ Please complete the setup at least a day before the workshop. MoveIt maintainers
 
 Use one of following two options:
 
-1. **Docker**: See [these detailed instructions](https://github.com/hello-robot/stretch_ros2/blob/ros_world2021/README.md#linux-installation-with-docker).
-2. **ROS 2 Galactic installation**: See [these detailed instructions](https://github.com/hello-robot/stretch_ros2/blob/ros_world2021/README.md#linux-installation-source).
+1. **Docker**: See [these detailed instructions](https://github.com/AndyZe/stretch_ros2/tree/ros_world2021/README.md#linux-installation-with-docker).
+2. **ROS 2 Galactic installation**: See [these detailed instructions](https://github.com/AndyZe/stretch_ros2/tree/ros_world2021/README.md#linux-installation-source).
 
 Please go through these instructions _before_ the workshop. The docker image is 6.29GB in size, so this may take some time to download (depending on the speed of your internet connection).
 
 ### Further reading & watching
 
-* The code for the workshop can be found in the `ros_world2021` branch of the [`stretch_ros2` repo](https://github.com/hello-robot/stretch_ros2/tree/ros_world2021) on GitHub.
+* The code for the workshop can be found in the `ros_world2021` branch of the [`stretch_ros2` repo](https://github.com/AndyZe/stretch_ros2/tree/ros_world2021) on GitHub.
 * The [MoveIt Concepts page](https://moveit.ros.org/documentation/concepts/) goes into more detail than the workshop in describing the general structure of MoveIt.
 * There are [many more MoveIt 2 tutorials](http://moveit.picknik.ai) available.
 * [This paper](https://arxiv.org/abs/2109.10892) describes in more detail the design of the Stretch mobile manipulator from Hello Robotics, while more information on the Stretch payload and pulling force can be found [here](Stretch Payload & Pulling Force.pdf).
 * Video demos from the different _Guided exploration_ sessions:
   1. A demonstration of the MoveIt motion planning panel in RViz:<br>
      <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/MwDs_uX6SKw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  2. A basic pick & place demo [[code]](https://github.com/hello-robot/stretch_ros2/blob/ros_world2021/stretch_roscon_demos/src/move_group_interface_demo.cpp):<br>
+  2. A basic pick & place demo [[code]](https://github.com/AndyZe/stretch_ros2/blob/ros_world2021/stretch_roscon_demos/src/move_group_interface_demo.cpp):<br>
      <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/auazxjtOjsY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   3. An advanced pick & place demo using the MoveIt Task Constructor [[code]](https://github.com/PickNikRobotics/stretch_moveit_plugins/tree/main/pick_place_task):<br>
      <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Tm93GFlT234" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/index.markdown
+++ b/index.markdown
@@ -51,14 +51,14 @@ redirect_from: '/moveit/'
                             <img class="robot-hand" src="/assets/images/main/hero.png" alt="Robot hand">
                             <div class="info-box-content">
                                 <div class="info-box-header">
-                                    Latest: <b>MoveIt 2 Iron</b>
+                                    Latest: <b>MoveIt Iron</b>
                                 </div>
-                                <a href="/install-moveit2/source/" class="info-box-button button">Build MoveIt 2 from Source</a>
+                                <a href="/install-moveit2/binary/" class="info-box-button button">Install MoveIt From Debian</a>
                                 <div class="info-box-version">
                                     Ubuntu 22.04
                                 </div>
                                 <div class="link-group">
-                                    <a href="/install/" class="info-box-link">Install MoveIt 1.0</a>
+                                    <a href="/install-moveit2/source/" class="info-box-link">Install From Source</a>
                                     <span>|</span>
                                     <a href="https://github.com/ros-planning/moveit2" target="_blank" class="info-box-link">View on Github</a>
                                 </div>

--- a/index.markdown
+++ b/index.markdown
@@ -58,7 +58,7 @@ redirect_from: '/moveit/'
                                     Ubuntu 22.04
                                 </div>
                                 <div class="link-group">
-                                    <a href="/install-moveit2/source/" class="info-box-link">Install From Source</a>
+                                    <a href="/install-moveit2/source/" class="info-box-link">Build From Source</a>
                                     <span>|</span>
                                     <a href="https://github.com/ros-planning/moveit2" target="_blank" class="info-box-link">View on Github</a>
                                 </div>


### PR DESCRIPTION
- The main call to action of "install from source" is left over from when moveit 2 didn't have binaries yet
- De-emphasize ROS 1 version as its really old now, replace that link with build from source instructions
- New branding of MoveIt is suppose to de-emphasize 1 vs 2, so remove "2" from Iron name