### PR TITLE
Gate Google Analytics and Leadfeeder trackers behind cookie consent

### DIFF
--- a/_includes/default.html
+++ b/_includes/default.html
@@ -52,8 +52,8 @@ ript>
     <![endif]-->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"> </script>
     <script type="text/javascript" src="/assets/bootstrap-4.1.0-dist/js/bootstrap.min.js" ></script>
-    <!-- Consent-gated analytics: the Leadfeeder tracker loads only after opt-in
-         (see /assets/js/consent.js). The dead Universal Analytics tag
-         UA-108532843-1 was removed. -->
-    <script src="{{ '/assets/js/consent.js' | relative_url }}"></script>
+    <!-- Consent-gated analytics: Google Analytics 4 and the Leadfeeder tracker
+         load only after opt-in (see /assets/js/consent.js). The dead Universal
+         Analytics tag UA-108532843-1 was replaced by GA4. -->
+    <script defer src="{{ '/assets/js/consent.js' | relative_url }}"></script>
   </head>

--- a/_includes/default.html
+++ b/_includes/default.html
@@ -52,17 +52,8 @@ ript>
     <![endif]-->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"> </script>
     <script type="text/javascript" src="/assets/bootstrap-4.1.0-dist/js/bootstrap.min.js" ></script>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-108532843-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-108532843-1');
-    </script>
-    <!-- Leadfeeder Tracker -->
-    <script>
-      (function (ss, ex) { window.ldfdr = window.ldfdr || function () { (ldfdr._q = ldfdr._q || []).push([].slice.call(arguments)); }; (function (d, s) { fs = d.getElementsByTagName(s)[0]; function ce(src) { var cs = d.createElement(s); cs.src = src; cs.async = 1; fs.parentNode.insertBefore(cs, fs); }; ce('https://sc.lfeeder.com/lftracker_v1_' + ss + (ex ? '_' + ex : '') + '.js'); })(document, 'script'); })('lYNOR8xOKPOaWQJZ');
-    </script>
+    <!-- Consent-gated analytics: the Leadfeeder tracker loads only after opt-in
+         (see /assets/js/consent.js). The dead Universal Analytics tag
+         UA-108532843-1 was removed. -->
+    <script src="{{ '/assets/js/consent.js' | relative_url }}"></script>
   </head>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -108,6 +108,9 @@
         <a href="https://github.com/moveit/moveit.ros.org"
           >Edit website on <span class="color-blue">Github</span></a
         >
+        <button type="button" class="consent-reopen" data-consent-open>
+          Cookie settings
+        </button>
       </div>
     </div>
   </div>

--- a/_sass/_consent.scss
+++ b/_sass/_consent.scss
@@ -1,0 +1,90 @@
+// Cookie-consent banner. Gates the Leadfeeder tracker behind an opt-in.
+.consent-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background: $white;
+  color: $robots-black;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.2);
+
+  &__inner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px 24px;
+    max-width: 1140px;
+    margin: 0 auto;
+    padding: 16px 20px;
+  }
+
+  &__text {
+    flex: 1 1 320px;
+  }
+
+  &__title {
+    margin: 0 0 4px;
+    font-size: 18px;
+    color: $robots-black;
+    text-indent: 0;
+  }
+
+  &__text p {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+    color: $dark-text;
+
+    a {
+      color: $blue;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+}
+
+.consent-btn {
+  padding: 8px 22px;
+  border-radius: 4px;
+  font-size: 13px;
+  letter-spacing: 1px;
+  cursor: pointer;
+
+  &--accept {
+    background-color: $blue;
+    border: 1px solid $blue;
+    color: $white;
+
+    &:hover {
+      background-color: $white;
+      color: $blue;
+    }
+  }
+
+  &--reject {
+    background-color: transparent;
+    border: 1px solid rgba(0, 0, 0, 0.25);
+    color: $robots-black;
+
+    &:hover {
+      border-color: $robots-black;
+    }
+  }
+}
+
+// Lift the MoveIt Pro announcement banner above the consent banner while it is
+// open, and drop it back to its default position once a choice is made.
+.moveit_announcement_banner {
+  transition: bottom 0.2s ease;
+}
+
+body.consent-open .moveit_announcement_banner {
+  bottom: 115px;
+}

--- a/_sass/_consent.scss
+++ b/_sass/_consent.scss
@@ -88,3 +88,18 @@
 body.consent-open .moveit_announcement_banner {
   bottom: 115px;
 }
+
+// Footer "Cookie settings" link that reopens the consent banner. Sits on its
+// own line, centered, below the "Edit website on Github" link.
+.consent-reopen {
+  display: block;
+  width: fit-content;
+  margin: 8px auto 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  background: none;
+  border: none;
+  cursor: pointer;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -18,6 +18,7 @@
 @import 'robots';
 @import 'modal';
 @import 'install';
+@import 'consent';
 @import 'people';
 @import 'feedback';
 @import 'support';

--- a/assets/js/consent.js
+++ b/assets/js/consent.js
@@ -1,8 +1,9 @@
 /*
- * Consent manager for moveit.ai. The only third-party tag is the Leadfeeder
- * (Dealfront) visitor tracker; it loads only after the visitor opts in, so no
- * tracking cookies are set without consent. Mirrors the picknik.ai consent flow:
- * denied by default, granted on opt-in, cleared and reloaded on withdrawal.
+ * Consent manager for moveit.ai. Two third-party tags — Google Analytics 4
+ * (analytics) and the Dealfront (Leadfeeder) visitor tracker (advertising) —
+ * load only after the visitor opts in, so no tracking cookies are set without
+ * consent. Mirrors the picknik.ai consent flow: denied by default, granted on
+ * opt-in, cleared and reloaded on withdrawal.
  */
 (function () {
   'use strict';
@@ -10,12 +11,16 @@
   var COOKIE_NAME = 'pn_consent';
   var COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
   var SCHEMA_VERSION = 1; // re-ask when the cookie shape changes
+  var GA_MEASUREMENT_ID = 'G-0FNPMEP8NE';
   var LEADFEEDER_ID = 'lYNOR8xOKPOaWQJZ';
   var PRIVACY_POLICY_URL = 'https://picknik.ai/privacy-policy/';
 
-  // Cookie Leadfeeder drops; cleared when advertising consent is withdrawn.
-  var LF_COOKIES = ['_lfa'];
+  // Cookies the vendors drop; cleared when consent is withdrawn. _ga_<ID> and
+  // _gac_* vary per property, so they are matched by prefix.
+  var TRACKING_COOKIES = ['_ga', '_gid', '_gat', '_lfa'];
+  var TRACKING_COOKIE_PREFIXES = ['_ga_', '_gac_', '_lfa'];
 
+  var gaLoaded = false;
   var leadfeederLoaded = false;
   var banner = null;
 
@@ -27,21 +32,21 @@
     try {
       var parsed = JSON.parse(decodeURIComponent(match[1]));
       if (!parsed || parsed.v !== SCHEMA_VERSION) return null;
-      return { advertising: parsed.advertising === true };
+      return { analytics: parsed.analytics === true, advertising: parsed.advertising === true };
     } catch (e) {
       return null;
     }
   }
 
-  function writeConsent(advertising) {
-    // Same shape as picknik.ai's pn_consent; moveit.ai only exposes advertising
-    // (Leadfeeder), so the other categories are always false.
+  function writeConsent(granted) {
+    // Same shape as picknik.ai's pn_consent. moveit.ai's single Accept/Reject
+    // grants analytics (GA4) and advertising (Leadfeeder) together.
     var payload = {
       v: SCHEMA_VERSION,
       ts: new Date().toISOString(),
       functional: false,
-      analytics: false,
-      advertising: advertising === true
+      analytics: granted === true,
+      advertising: granted === true
     };
     document.cookie =
       COOKIE_NAME + '=' + encodeURIComponent(JSON.stringify(payload)) +
@@ -49,24 +54,32 @@
       (location.protocol === 'https:' ? ';Secure' : '');
   }
 
-  function hasLeadfeederCookies() {
+  function isTrackingCookie(name) {
+    if (TRACKING_COOKIES.indexOf(name) !== -1) return true;
+    for (var i = 0; i < TRACKING_COOKIE_PREFIXES.length; i++) {
+      if (name.indexOf(TRACKING_COOKIE_PREFIXES[i]) === 0) return true;
+    }
+    return false;
+  }
+
+  function hasTrackingCookies() {
     return document.cookie.split('; ').some(function (raw) {
-      return LF_COOKIES.indexOf(raw.split('=')[0]) !== -1;
+      return isTrackingCookie(raw.split('=')[0]);
     });
   }
 
-  function clearLeadfeederCookies() {
+  function clearTrackingCookies() {
     var host = location.hostname;
     var domains = ['', host, '.' + host];
-    // Leadfeeder may scope _lfa to the registrable domain so it's shared across
-    // subdomains; clear it there too (e.g. on www.moveit.ai). ES5 suffix check.
+    // GA4/Leadfeeder scope cookies to the registrable domain so they are shared
+    // across subdomains; clear them there too (e.g. on www.moveit.ai). ES5 check.
     var apex = '.moveit.ai';
     if (host.length > apex.length && host.slice(-apex.length) === apex) {
       domains.push(apex);
     }
     document.cookie.split('; ').forEach(function (raw) {
       var name = raw.split('=')[0];
-      if (LF_COOKIES.indexOf(name) === -1) return;
+      if (!isTrackingCookie(name)) return;
       domains.forEach(function (d) {
         document.cookie =
           name + '=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT' + (d ? ';domain=' + d : '');
@@ -74,7 +87,37 @@
     });
   }
 
-  /* ------------------------------------------------------------------ loader */
+  /* ------------------------------------------------------- google consent mode */
+
+  function initConsentMode() {
+    window.dataLayer = window.dataLayer || [];
+    // A plain function (not an arrow) so `arguments` is available — this is
+    // Google's canonical gtag shim.
+    window.gtag = function gtag() {
+      window.dataLayer.push(arguments);
+    };
+    // Denied is the starting point for everyone; GA is not loaded until opt-in.
+    window.gtag('consent', 'default', {
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      analytics_storage: 'denied'
+    });
+  }
+
+  /* ------------------------------------------------------------------ loaders */
+
+  function loadGA() {
+    if (gaLoaded) return;
+    gaLoaded = true;
+    window.gtag('consent', 'update', { analytics_storage: 'granted' });
+    var script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_MEASUREMENT_ID;
+    document.head.appendChild(script);
+    window.gtag('js', new Date());
+    window.gtag('config', GA_MEASUREMENT_ID);
+  }
 
   // The vendor snippet formerly inlined in _includes/default.html; runs only
   // after the visitor opts in.
@@ -95,19 +138,20 @@
 
   /* -------------------------------------------------------------------- banner */
 
-  function decide(advertising) {
-    writeConsent(advertising);
+  function decide(granted) {
+    writeConsent(granted);
     if (banner) banner.hidden = true;
     document.body.classList.remove('consent-open'); // drop the announcement banner back down
 
-    if (advertising) {
+    if (granted) {
+      loadGA();
       loadLeadfeeder();
       return;
     }
-    // Leadfeeder can't be unloaded once running: if it loaded this session or
+    // A loaded tag can't be pulled back out: if anything loaded this session or
     // left cookies behind, drop them and reload.
-    if (leadfeederLoaded || hasLeadfeederCookies()) {
-      clearLeadfeederCookies();
+    if (gaLoaded || leadfeederLoaded || hasTrackingCookies()) {
+      clearTrackingCookies();
       location.reload();
     }
   }
@@ -123,8 +167,8 @@
       '<div class="consent-banner__inner">' +
       '<div class="consent-banner__text">' +
       '<h2 class="consent-banner__title">Cookies? Your call.</h2>' +
-      '<p>This site uses cookies to understand ' +
-      'which organizations find MoveIt useful. It loads only if you allow it. See our ' +
+      '<p>This site uses cookies to understand which organizations find MoveIt ' +
+      'useful. It loads only if you allow it. See our ' +
       '<a href="' + PRIVACY_POLICY_URL + '" rel="noopener" target="_blank">Privacy Policy</a>.</p>' +
       '</div>' +
       '<div class="consent-banner__actions">' +
@@ -142,19 +186,32 @@
     document.body.appendChild(banner);
   }
 
+  function openBanner() {
+    if (!banner) return;
+    banner.hidden = false;
+    document.body.classList.add('consent-open'); // lift the announcement banner above ours
+  }
+
   function init() {
     buildBanner();
-    // `stored` is assigned in the boot block before init runs.
-    if (!stored && banner) {
-      banner.hidden = false;
-      document.body.classList.add('consent-open'); // lift the announcement banner above ours
-    }
+    if (!stored) openBanner(); // `stored` is assigned in the boot block before init runs
+
+    // Footer "Cookie settings" link reopens the banner so a visitor can change
+    // (and withdraw) their choice as easily as they gave it.
+    document.addEventListener('click', function (event) {
+      var trigger = event.target.closest ? event.target.closest('[data-consent-open]') : null;
+      if (!trigger) return;
+      event.preventDefault();
+      openBanner();
+    });
   }
 
   /* --------------------------------------------------------------------- boot */
 
+  initConsentMode();
   var stored = readConsent();
-  if (stored && stored.advertising) loadLeadfeeder(); // returning opt-in tracks from the start
+  if (stored && stored.analytics) loadGA(); // returning opt-in tracks from the start
+  if (stored && stored.advertising) loadLeadfeeder();
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);

--- a/assets/js/consent.js
+++ b/assets/js/consent.js
@@ -1,0 +1,164 @@
+/*
+ * Consent manager for moveit.ai. The only third-party tag is the Leadfeeder
+ * (Dealfront) visitor tracker; it loads only after the visitor opts in, so no
+ * tracking cookies are set without consent. Mirrors the picknik.ai consent flow:
+ * denied by default, granted on opt-in, cleared and reloaded on withdrawal.
+ */
+(function () {
+  'use strict';
+
+  var COOKIE_NAME = 'pn_consent';
+  var COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+  var SCHEMA_VERSION = 1; // re-ask when the cookie shape changes
+  var LEADFEEDER_ID = 'lYNOR8xOKPOaWQJZ';
+  var PRIVACY_POLICY_URL = 'https://picknik.ai/privacy-policy/';
+
+  // Cookie Leadfeeder drops; cleared when advertising consent is withdrawn.
+  var LF_COOKIES = ['_lfa'];
+
+  var leadfeederLoaded = false;
+  var banner = null;
+
+  /* ------------------------------------------------------------------ cookie */
+
+  function readConsent() {
+    var match = document.cookie.match(new RegExp('(?:^|; )' + COOKIE_NAME + '=([^;]*)'));
+    if (!match) return null;
+    try {
+      var parsed = JSON.parse(decodeURIComponent(match[1]));
+      if (!parsed || parsed.v !== SCHEMA_VERSION) return null;
+      return { advertising: parsed.advertising === true };
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function writeConsent(advertising) {
+    // Same shape as picknik.ai's pn_consent; moveit.ai only exposes advertising
+    // (Leadfeeder), so the other categories are always false.
+    var payload = {
+      v: SCHEMA_VERSION,
+      ts: new Date().toISOString(),
+      functional: false,
+      analytics: false,
+      advertising: advertising === true
+    };
+    document.cookie =
+      COOKIE_NAME + '=' + encodeURIComponent(JSON.stringify(payload)) +
+      ';path=/;max-age=' + COOKIE_MAX_AGE + ';SameSite=Lax' +
+      (location.protocol === 'https:' ? ';Secure' : '');
+  }
+
+  function hasLeadfeederCookies() {
+    return document.cookie.split('; ').some(function (raw) {
+      return LF_COOKIES.indexOf(raw.split('=')[0]) !== -1;
+    });
+  }
+
+  function clearLeadfeederCookies() {
+    var host = location.hostname;
+    var domains = ['', host, '.' + host];
+    // Leadfeeder may scope _lfa to the registrable domain so it's shared across
+    // subdomains; clear it there too (e.g. on www.moveit.ai). ES5 suffix check.
+    var apex = '.moveit.ai';
+    if (host.length > apex.length && host.slice(-apex.length) === apex) {
+      domains.push(apex);
+    }
+    document.cookie.split('; ').forEach(function (raw) {
+      var name = raw.split('=')[0];
+      if (LF_COOKIES.indexOf(name) === -1) return;
+      domains.forEach(function (d) {
+        document.cookie =
+          name + '=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT' + (d ? ';domain=' + d : '');
+      });
+    });
+  }
+
+  /* ------------------------------------------------------------------ loader */
+
+  // The vendor snippet formerly inlined in _includes/default.html; runs only
+  // after the visitor opts in.
+  function loadLeadfeeder() {
+    if (leadfeederLoaded) return;
+    leadfeederLoaded = true;
+    window.ldfdr =
+      window.ldfdr ||
+      function () {
+        (window.ldfdr._q = window.ldfdr._q || []).push([].slice.call(arguments));
+      };
+    var first = document.getElementsByTagName('script')[0];
+    var script = document.createElement('script');
+    script.src = 'https://sc.lfeeder.com/lftracker_v1_' + LEADFEEDER_ID + '.js';
+    script.async = true;
+    first.parentNode.insertBefore(script, first);
+  }
+
+  /* -------------------------------------------------------------------- banner */
+
+  function decide(advertising) {
+    writeConsent(advertising);
+    if (banner) banner.hidden = true;
+    document.body.classList.remove('consent-open'); // drop the announcement banner back down
+
+    if (advertising) {
+      loadLeadfeeder();
+      return;
+    }
+    // Leadfeeder can't be unloaded once running: if it loaded this session or
+    // left cookies behind, drop them and reload.
+    if (leadfeederLoaded || hasLeadfeederCookies()) {
+      clearLeadfeederCookies();
+      location.reload();
+    }
+  }
+
+  function buildBanner() {
+    banner = document.createElement('div');
+    banner.className = 'consent-banner';
+    banner.setAttribute('role', 'dialog');
+    banner.setAttribute('aria-live', 'polite');
+    banner.setAttribute('aria-label', 'Cookie consent');
+    banner.hidden = true;
+    banner.innerHTML =
+      '<div class="consent-banner__inner">' +
+      '<div class="consent-banner__text">' +
+      '<h2 class="consent-banner__title">Cookies? Your call.</h2>' +
+      '<p>This site uses the Dealfront (Leadfeeder) visitor tracker to understand ' +
+      'which organizations find MoveIt useful. It loads only if you allow it. See our ' +
+      '<a href="' + PRIVACY_POLICY_URL + '" rel="noopener" target="_blank">Privacy Policy</a>.</p>' +
+      '</div>' +
+      '<div class="consent-banner__actions">' +
+      '<button type="button" class="consent-btn consent-btn--accept" data-consent-action="accept">Accept</button>' +
+      '<button type="button" class="consent-btn consent-btn--reject" data-consent-action="reject">Reject</button>' +
+      '</div>' +
+      '</div>';
+
+    banner.addEventListener('click', function (event) {
+      var action = event.target.getAttribute('data-consent-action');
+      if (action === 'accept') decide(true);
+      if (action === 'reject') decide(false);
+    });
+
+    document.body.appendChild(banner);
+  }
+
+  function init() {
+    buildBanner();
+    // `stored` is assigned in the boot block before init runs.
+    if (!stored && banner) {
+      banner.hidden = false;
+      document.body.classList.add('consent-open'); // lift the announcement banner above ours
+    }
+  }
+
+  /* --------------------------------------------------------------------- boot */
+
+  var stored = readConsent();
+  if (stored && stored.advertising) loadLeadfeeder(); // returning opt-in tracks from the start
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/assets/js/consent.js
+++ b/assets/js/consent.js
@@ -123,7 +123,7 @@
       '<div class="consent-banner__inner">' +
       '<div class="consent-banner__text">' +
       '<h2 class="consent-banner__title">Cookies? Your call.</h2>' +
-      '<p>This site uses the Dealfront (Leadfeeder) visitor tracker to understand ' +
+      '<p>This site uses cookies to understand ' +
       'which organizations find MoveIt useful. It loads only if you allow it. See our ' +
       '<a href="' + PRIVACY_POLICY_URL + '" rel="noopener" target="_blank">Privacy Policy</a>.</p>' +
       '</div>' +


### PR DESCRIPTION
[Screencast from 2026-07-20 17-03-47.webm](https://github.com/user-attachments/assets/b5a03faf-c115-4274-82d7-3da53fd66f52)


## Motivation

moveit.ai loaded two visitor-tracking scripts on every page with no consent gate:

1. A legacy **Google Universal Analytics** tag (`UA-108532843-1`). Google retired Universal Analytics in 2024, so this property no longer collected anything — it just set `_ga` cookies for a dead endpoint.
2. The **Dealfront (Leadfeeder)** visitor tracker, which identifies visitors and sets cookies on page load.

Both ran before the visitor had any choice.

## Changes

- **Replace the dead Universal Analytics tag with a working Google Analytics 4 tag** (`G-0FNPMEP8NE`), gated behind an opt-in consent banner instead of firing on load.
- **Gate the Leadfeeder tracker** behind the same consent.
- Neither tag is present in the page markup anymore — the consent module (`assets/js/consent.js`) injects them only after opt-in. Google Consent Mode defaults `analytics_storage` (and ad storage) to `denied`; a single **Accept** grants both and loads GA4 + Leadfeeder, **Reject** keeps them off, and the choice persists in a `pn_consent` cookie (host-only, `SameSite=Lax`, `Secure` on https).
- **Withdrawal** is as easy as consent: a "Cookie settings" link in the footer reopens the banner; changing to Reject clears the GA4 (`_ga*`, `_gac_*`) and Leadfeeder (`_lfa`) cookies and reloads.
- The `consent.js` script tag is `defer`red so it no longer blocks page rendering.

## Testing

- `bundle exec jekyll build` succeeds; the generated `<head>` contains no tracking scripts.
- Browser-verified on the built site: a fresh visit shows the banner and loads no tracker, with Consent Mode `denied`; **Accept** loads GA4 (`gtag/js?id=G-0FNPMEP8NE`) + Leadfeeder and writes `pn_consent{analytics:true, advertising:true}`; **Reject** loads nothing; the footer "Cookie settings" link reopens the banner (withdrawal path); the MoveIt Pro announcement widget lifts above the banner and drops back once a choice is made.

_Note: a single Accept/Reject covers both analytics (GA4) and the Leadfeeder tracker rather than offering per-category toggles — flagging in case granular consent is preferred._
