### PR TITLE
Replace unused Mailchimp newsletter link with a consent-gated HubSpot form

### DIFF
--- a/_sass/_block.scss
+++ b/_sass/_block.scss
@@ -317,5 +317,86 @@
       font-weight: bold;
       margin-bottom: 24px;
     }
+
+    // The consent fallback is a <p>; keep it lighter than the heading above.
+    .hs-newsletter-fallback {
+      font-size: 15px;
+      font-weight: normal;
+    }
+
+    // Style the embedded HubSpot newsletter form to match the site.
+    #newsletter-form {
+      max-width: 420px;
+      margin: 8px auto 0;
+      text-align: left;
+
+      // Hidden UTM fields still render a wrapper; collapse them so they
+      // don't leave empty gaps between the visible fields.
+      [class*="hs_utm"],
+      .hs_gclid {
+        display: none;
+      }
+
+      .hs-form-field {
+        margin-bottom: 14px;
+      }
+
+      // Field labels only — error labels live in .hs-error-msgs below.
+      .hs-form-field > label {
+        display: block;
+        font-size: 13px;
+        font-weight: 600;
+        margin-bottom: 6px;
+        color: $dark-text;
+      }
+
+      .hs-input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 10px 14px;
+        font: inherit;
+        font-size: 15px;
+        color: $dark-blue;
+        background: $white;
+        border: 1px solid rgba(25, 26, 32, 0.2);
+        border-radius: 4px;
+
+        &:focus {
+          outline: none;
+          border-color: $blue;
+        }
+      }
+
+      .hs-error-msgs {
+        list-style: none;
+        padding: 0;
+        margin: 6px 0 0;
+
+        label {
+          color: $red;
+          font-size: 13px;
+          font-weight: normal;
+        }
+      }
+
+      .hs-button {
+        margin-top: 4px;
+        padding: 10px 30px;
+        background-color: $blue;
+        color: $white;
+        border: 1px solid $blue;
+        border-radius: 4px;
+        letter-spacing: 1px;
+        font-size: 13px;
+        font-weight: bold;
+        text-transform: uppercase;
+        cursor: pointer;
+
+        &:hover {
+          background-color: $white;
+          color: $blue;
+        }
+      }
+    }
   }
 }

--- a/_sass/_block.scss
+++ b/_sass/_block.scss
@@ -330,6 +330,14 @@
       margin: 8px auto 0;
       text-align: left;
 
+      // Loading / error line shown before the form renders (or on failure).
+      .hs-newsletter-status {
+        font-size: 15px;
+        font-weight: normal;
+        color: $text;
+        margin: 0;
+      }
+
       // Hidden UTM fields still render a wrapper; collapse them so they
       // don't leave empty gaps between the visible fields.
       [class*="hs_utm"],

--- a/_sass/_block.scss
+++ b/_sass/_block.scss
@@ -318,12 +318,6 @@
       margin-bottom: 24px;
     }
 
-    // The consent fallback is a <p>; keep it lighter than the heading above.
-    .hs-newsletter-fallback {
-      font-size: 15px;
-      font-weight: normal;
-    }
-
     // Style the embedded HubSpot newsletter form to match the site.
     #newsletter-form {
       max-width: 420px;

--- a/about/get_involved/index.markdown
+++ b/about/get_involved/index.markdown
@@ -63,7 +63,7 @@ title: Get Involved
 <div class="row">
   <div class="get-involved-footer">
     <p>You can also get the <a href="https://picknik.ai/">PickNik Robotics</a> quarterly newsletter on MoveIt</p>
-    <div id="newsletter-form" class="hs-newsletter-form"></div>
-    <p id="newsletter-consent-fallback" class="hs-newsletter-fallback" hidden>To subscribe, please <button type="button" class="consent-reopen-inline" data-consent-open style="background:none;border:0;padding:0;font:inherit;color:inherit;text-decoration:underline;cursor:pointer">accept cookies</button> — the signup form loads once you do.</p>
+    <button type="button" id="newsletter-toggle" class="button button-transparent button-transparent__blue">SUBSCRIBE TO OUR NEWSLETTER</button>
+    <div id="newsletter-form" class="hs-newsletter-form" hidden></div>
   </div>
 </div>

--- a/about/get_involved/index.markdown
+++ b/about/get_involved/index.markdown
@@ -63,6 +63,7 @@ title: Get Involved
 <div class="row">
   <div class="get-involved-footer">
     <p>You can also get the <a href="https://picknik.ai/">PickNik Robotics</a> quarterly newsletter on MoveIt</p>
-    <a class="button button-transparent button-transparent__blue" href="https://picknik.us20.list-manage.com/subscribe?u=ec7904f1f579094c8e83e79e8&id=196b3fc03e" target="_blank">SUBSCRIBE TO OUR NEWSLETTER</a>
+    <div id="newsletter-form" class="hs-newsletter-form"></div>
+    <p id="newsletter-consent-fallback" class="hs-newsletter-fallback" hidden>To subscribe, please <a href="#" data-consent-open>accept cookies</a> — the signup form loads once you do.</p>
   </div>
 </div>

--- a/about/get_involved/index.markdown
+++ b/about/get_involved/index.markdown
@@ -64,6 +64,6 @@ title: Get Involved
   <div class="get-involved-footer">
     <p>You can also get the <a href="https://picknik.ai/">PickNik Robotics</a> quarterly newsletter on MoveIt</p>
     <div id="newsletter-form" class="hs-newsletter-form"></div>
-    <p id="newsletter-consent-fallback" class="hs-newsletter-fallback" hidden>To subscribe, please <a href="#" data-consent-open>accept cookies</a> — the signup form loads once you do.</p>
+    <p id="newsletter-consent-fallback" class="hs-newsletter-fallback" hidden>To subscribe, please <button type="button" class="consent-reopen-inline" data-consent-open style="background:none;border:0;padding:0;font:inherit;color:inherit;text-decoration:underline;cursor:pointer">accept cookies</button> — the signup form loads once you do.</p>
   </div>
 </div>

--- a/assets/js/consent.js
+++ b/assets/js/consent.js
@@ -26,7 +26,8 @@
 
   var gaLoaded = false;
   var leadfeederLoaded = false;
-  var hubspotFormLoaded = false;
+  var hubspotFormLoading = false; // embed script injected, form not yet rendered
+  var hubspotFormReady = false;   // hbspt.forms.create has rendered the form
   var banner = null;
 
   /* ------------------------------------------------------------------ cookie */
@@ -144,35 +145,56 @@
   // The PickNik newsletter signup on the Get Involved page. The HubSpot embed
   // pulls js.hsforms.net and sets hubspotutk, so it loads only after opt-in.
   function loadHubSpotForm() {
-    if (hubspotFormLoaded) return;
+    if (hubspotFormReady || hubspotFormLoading) return;
     var target = document.getElementById('newsletter-form');
     if (!target) return; // the form only exists on the Get Involved page
-    hubspotFormLoaded = true;
+    hubspotFormLoading = true;
+
+    // On failure, reset so a later opt-in (or reopening Cookie settings) can
+    // retry, and leave a message rather than an empty form area.
+    function fail() {
+      if (hubspotFormReady) return;
+      hubspotFormLoading = false;
+      var fb = document.getElementById('newsletter-consent-fallback');
+      if (fb) {
+        fb.textContent = 'The subscribe form could not load. Please refresh to try again.';
+        fb.hidden = false;
+      }
+    }
+
     var script = document.createElement('script');
     script.src = 'https://js.hsforms.net/forms/embed/v2.js';
     script.charset = 'utf-8';
     script.async = true;
+    script.onerror = fail;
     script.onload = function () {
-      if (window.hbspt && window.hbspt.forms) {
-        window.hbspt.forms.create({
-          portalId: HUBSPOT_PORTAL_ID,
-          formId: HUBSPOT_FORM_ID,
-          target: '#newsletter-form'
-        });
-      }
+      if (!(window.hbspt && window.hbspt.forms)) { fail(); return; }
+      window.hbspt.forms.create({
+        portalId: HUBSPOT_PORTAL_ID,
+        formId: HUBSPOT_FORM_ID,
+        target: '#newsletter-form',
+        onFormReady: function () {
+          hubspotFormReady = true;
+          hubspotFormLoading = false;
+          var fb = document.getElementById('newsletter-consent-fallback');
+          if (fb) fb.hidden = true; // hide the prompt only once the form has rendered
+        }
+      });
     };
+    // If the form never renders (bad id, outage), surface the error instead of
+    // an empty area and allow a retry.
+    setTimeout(fail, 10000);
     document.head.appendChild(script);
   }
 
-  // Load the form when consent is granted; otherwise show the "accept cookies"
-  // prompt in its place. No-op on pages without the form.
+  // Load the form when consent is granted (the prompt hides once it renders);
+  // otherwise show the "accept cookies" prompt. No-op on pages without the form.
   function updateNewsletterForm(granted) {
-    var fallback = document.getElementById('newsletter-consent-fallback');
     if (granted) {
       loadHubSpotForm();
-      if (fallback) fallback.hidden = true;
-    } else if (fallback) {
-      fallback.hidden = false;
+    } else {
+      var fallback = document.getElementById('newsletter-consent-fallback');
+      if (fallback) fallback.hidden = false;
     }
   }
 
@@ -192,7 +214,7 @@
     updateNewsletterForm(false);
     // A loaded tag can't be pulled back out: if anything loaded this session or
     // left cookies behind, drop them and reload.
-    if (gaLoaded || leadfeederLoaded || hubspotFormLoaded || hasTrackingCookies()) {
+    if (gaLoaded || leadfeederLoaded || hubspotFormReady || hubspotFormLoading || hasTrackingCookies()) {
       clearTrackingCookies();
       location.reload();
     }

--- a/assets/js/consent.js
+++ b/assets/js/consent.js
@@ -1,9 +1,10 @@
 /*
- * Consent manager for moveit.ai. Two third-party tags — Google Analytics 4
- * (analytics) and the Dealfront (Leadfeeder) visitor tracker (advertising) —
- * load only after the visitor opts in, so no tracking cookies are set without
- * consent. Mirrors the picknik.ai consent flow: denied by default, granted on
- * opt-in, cleared and reloaded on withdrawal.
+ * Consent manager for moveit.ai. Third-party tags — Google Analytics 4
+ * (analytics), the Dealfront (Leadfeeder) visitor tracker (advertising), and
+ * the HubSpot newsletter form on Get Involved — load only after the visitor
+ * opts in, so no tracking cookies are set without consent. Mirrors the
+ * picknik.ai consent flow: denied by default, granted on opt-in, cleared and
+ * reloaded on withdrawal.
  */
 (function () {
   'use strict';
@@ -13,15 +14,19 @@
   var SCHEMA_VERSION = 1; // re-ask when the cookie shape changes
   var GA_MEASUREMENT_ID = 'G-0FNPMEP8NE';
   var LEADFEEDER_ID = 'lYNOR8xOKPOaWQJZ';
+  var HUBSPOT_PORTAL_ID = '45692735';
+  var HUBSPOT_FORM_ID = 'dea35ae4-e2aa-4a2e-9edb-ef5af8a38626';
   var PRIVACY_POLICY_URL = 'https://picknik.ai/privacy-policy/';
 
   // Cookies the vendors drop; cleared when consent is withdrawn. _ga_<ID> and
-  // _gac_* vary per property, so they are matched by prefix.
-  var TRACKING_COOKIES = ['_ga', '_gid', '_gat', '_lfa'];
+  // _gac_* vary per property, so they are matched by prefix. The __hs*/hubspotutk
+  // cookies come from the newsletter form embed (Get Involved page).
+  var TRACKING_COOKIES = ['_ga', '_gid', '_gat', '_lfa', 'hubspotutk', '__hstc', '__hssc', '__hssrc'];
   var TRACKING_COOKIE_PREFIXES = ['_ga_', '_gac_', '_lfa'];
 
   var gaLoaded = false;
   var leadfeederLoaded = false;
+  var hubspotFormLoaded = false;
   var banner = null;
 
   /* ------------------------------------------------------------------ cookie */
@@ -136,6 +141,41 @@
     first.parentNode.insertBefore(script, first);
   }
 
+  // The PickNik newsletter signup on the Get Involved page. The HubSpot embed
+  // pulls js.hsforms.net and sets hubspotutk, so it loads only after opt-in.
+  function loadHubSpotForm() {
+    if (hubspotFormLoaded) return;
+    var target = document.getElementById('newsletter-form');
+    if (!target) return; // the form only exists on the Get Involved page
+    hubspotFormLoaded = true;
+    var script = document.createElement('script');
+    script.src = 'https://js.hsforms.net/forms/embed/v2.js';
+    script.charset = 'utf-8';
+    script.async = true;
+    script.onload = function () {
+      if (window.hbspt && window.hbspt.forms) {
+        window.hbspt.forms.create({
+          portalId: HUBSPOT_PORTAL_ID,
+          formId: HUBSPOT_FORM_ID,
+          target: '#newsletter-form'
+        });
+      }
+    };
+    document.head.appendChild(script);
+  }
+
+  // Load the form when consent is granted; otherwise show the "accept cookies"
+  // prompt in its place. No-op on pages without the form.
+  function updateNewsletterForm(granted) {
+    var fallback = document.getElementById('newsletter-consent-fallback');
+    if (granted) {
+      loadHubSpotForm();
+      if (fallback) fallback.hidden = true;
+    } else if (fallback) {
+      fallback.hidden = false;
+    }
+  }
+
   /* -------------------------------------------------------------------- banner */
 
   function decide(granted) {
@@ -146,11 +186,13 @@
     if (granted) {
       loadGA();
       loadLeadfeeder();
+      updateNewsletterForm(true);
       return;
     }
+    updateNewsletterForm(false);
     // A loaded tag can't be pulled back out: if anything loaded this session or
     // left cookies behind, drop them and reload.
-    if (gaLoaded || leadfeederLoaded || hasTrackingCookies()) {
+    if (gaLoaded || leadfeederLoaded || hubspotFormLoaded || hasTrackingCookies()) {
       clearTrackingCookies();
       location.reload();
     }
@@ -195,6 +237,10 @@
   function init() {
     buildBanner();
     if (!stored) openBanner(); // `stored` is assigned in the boot block before init runs
+
+    // Reflect stored consent in the newsletter form: load it for returning
+    // opt-ins, show the "accept cookies" prompt otherwise (no-op off that page).
+    updateNewsletterForm(!!(stored && stored.analytics));
 
     // Footer "Cookie settings" link reopens the banner so a visitor can change
     // (and withdraw) their choice as easily as they gave it.

--- a/assets/js/consent.js
+++ b/assets/js/consent.js
@@ -1,8 +1,9 @@
 /*
  * Consent manager for moveit.ai. Third-party tags — Google Analytics 4
  * (analytics), the Dealfront (Leadfeeder) visitor tracker (advertising), and
- * the HubSpot newsletter form on Get Involved — load only after the visitor
- * opts in, so no tracking cookies are set without consent. Mirrors the
+ * the HubSpot newsletter form on Get Involved (behind a Subscribe button) —
+ * load only after the visitor opts in, so no tracking cookies are set without
+ * consent. Mirrors the
  * picknik.ai consent flow: denied by default, granted on opt-in, cleared and
  * reloaded on withdrawal.
  */
@@ -28,6 +29,7 @@
   var leadfeederLoaded = false;
   var hubspotFormLoading = false; // embed script injected, form not yet rendered
   var hubspotFormReady = false;   // hbspt.forms.create has rendered the form
+  var newsletterRequested = false; // visitor clicked the Subscribe button
   var banner = null;
 
   /* ------------------------------------------------------------------ cookie */
@@ -202,17 +204,16 @@
     document.head.appendChild(script);
   }
 
-  // Consent granted: hide the prompt and load the form (which shows its own
-  // loading/error status). Otherwise show the untouched consent prompt. No-op on
-  // pages without the form.
-  function updateNewsletterForm(granted) {
-    var fallback = document.getElementById('newsletter-consent-fallback');
-    if (granted) {
-      if (fallback) fallback.hidden = true;
-      loadHubSpotForm();
-    } else if (fallback) {
-      fallback.hidden = false;
-    }
+  // Swap the "Subscribe" button for the form and load it. Called when the
+  // visitor clicks Subscribe with consent already granted, or right after they
+  // grant it from the banner that click opened.
+  function revealNewsletterForm() {
+    var toggle = document.getElementById('newsletter-toggle');
+    var target = document.getElementById('newsletter-form');
+    if (!target) return; // the form only exists on the Get Involved page
+    if (toggle) toggle.hidden = true;
+    target.hidden = false;
+    loadHubSpotForm();
   }
 
   /* -------------------------------------------------------------------- banner */
@@ -225,10 +226,10 @@
     if (granted) {
       loadGA();
       loadLeadfeeder();
-      updateNewsletterForm(true);
+      // If the visitor reached the banner by clicking Subscribe, show the form now.
+      if (newsletterRequested) revealNewsletterForm();
       return;
     }
-    updateNewsletterForm(false);
     // A loaded tag can't be pulled back out: if anything loaded this session or
     // left cookies behind, drop them and reload.
     if (gaLoaded || leadfeederLoaded || hubspotFormReady || hubspotFormLoading || hasTrackingCookies()) {
@@ -277,9 +278,21 @@
     buildBanner();
     if (!stored) openBanner(); // `stored` is assigned in the boot block before init runs
 
-    // Reflect stored consent in the newsletter form: load it for returning
-    // opt-ins, show the "accept cookies" prompt otherwise (no-op off that page).
-    updateNewsletterForm(!!(stored && stored.analytics));
+    // Newsletter: reveal the form only when the visitor clicks Subscribe. With
+    // consent already given, load it in place; otherwise open the banner and
+    // reveal once they accept (handled in decide()).
+    document.addEventListener('click', function (event) {
+      var toggle = event.target.closest ? event.target.closest('#newsletter-toggle') : null;
+      if (!toggle) return;
+      event.preventDefault();
+      newsletterRequested = true;
+      var consent = readConsent();
+      if (consent && consent.analytics) {
+        revealNewsletterForm();
+      } else {
+        openBanner();
+      }
+    });
 
     // Footer "Cookie settings" link reopens the banner so a visitor can change
     // (and withdraw) their choice as easily as they gave it.

--- a/assets/js/consent.js
+++ b/assets/js/consent.js
@@ -142,6 +142,18 @@
     first.parentNode.insertBefore(script, first);
   }
 
+  // Loading/error messages live inside the form container, separate from the
+  // consent prompt so its Cookie-settings control is never overwritten.
+  function setFormStatus(target, message) {
+    var status = target.querySelector('.hs-newsletter-status');
+    if (!status) {
+      status = document.createElement('p');
+      status.className = 'hs-newsletter-status';
+      target.appendChild(status);
+    }
+    status.textContent = message;
+  }
+
   // The PickNik newsletter signup on the Get Involved page. The HubSpot embed
   // pulls js.hsforms.net and sets hubspotutk, so it loads only after opt-in.
   function loadHubSpotForm() {
@@ -150,17 +162,20 @@
     if (!target) return; // the form only exists on the Get Involved page
     hubspotFormLoading = true;
 
-    // On failure, reset so a later opt-in (or reopening Cookie settings) can
-    // retry, and leave a message rather than an empty form area.
+    var timeoutId = null;
+    function stopLoading() {
+      hubspotFormLoading = false;
+      if (timeoutId) { clearTimeout(timeoutId); timeoutId = null; }
+    }
+    // Reset so a later opt-in (or reopening Cookie settings) can retry, and
+    // show a message in the form area rather than a blank space.
     function fail() {
       if (hubspotFormReady) return;
-      hubspotFormLoading = false;
-      var fb = document.getElementById('newsletter-consent-fallback');
-      if (fb) {
-        fb.textContent = 'The subscribe form could not load. Please refresh to try again.';
-        fb.hidden = false;
-      }
+      stopLoading();
+      setFormStatus(target, 'The subscribe form could not load. Please refresh to try again.');
     }
+
+    setFormStatus(target, 'Loading the subscribe form…');
 
     var script = document.createElement('script');
     script.src = 'https://js.hsforms.net/forms/embed/v2.js';
@@ -175,26 +190,28 @@
         target: '#newsletter-form',
         onFormReady: function () {
           hubspotFormReady = true;
-          hubspotFormLoading = false;
-          var fb = document.getElementById('newsletter-consent-fallback');
-          if (fb) fb.hidden = true; // hide the prompt only once the form has rendered
+          stopLoading();
+          var status = target.querySelector('.hs-newsletter-status');
+          if (status) status.parentNode.removeChild(status);
         }
       });
     };
     // If the form never renders (bad id, outage), surface the error instead of
-    // an empty area and allow a retry.
-    setTimeout(fail, 10000);
+    // a blank area. Cleared in stopLoading() so a retry can't hit a stale timer.
+    timeoutId = setTimeout(fail, 10000);
     document.head.appendChild(script);
   }
 
-  // Load the form when consent is granted (the prompt hides once it renders);
-  // otherwise show the "accept cookies" prompt. No-op on pages without the form.
+  // Consent granted: hide the prompt and load the form (which shows its own
+  // loading/error status). Otherwise show the untouched consent prompt. No-op on
+  // pages without the form.
   function updateNewsletterForm(granted) {
+    var fallback = document.getElementById('newsletter-consent-fallback');
     if (granted) {
+      if (fallback) fallback.hidden = true;
       loadHubSpotForm();
-    } else {
-      var fallback = document.getElementById('newsletter-consent-fallback');
-      if (fallback) fallback.hidden = false;
+    } else if (fallback) {
+      fallback.hidden = false;
     }
   }
 


### PR DESCRIPTION
<img width="1742" height="1131" alt="Screenshot from 2026-08-25 10-35-52" src="https://github.com/user-attachments/assets/2f32a2e5-277b-4f7b-bea3-7285e81cf757" />

<img width="1788" height="760" alt="Screenshot from 2026-08-25 10-36-19" src="https://github.com/user-attachments/assets/b3d48c6e-09c6-437a-9ad3-b1e0b2efdc45" />

<img width="1578" height="155" alt="Screenshot from 2026-08-25 10-38-47" src="https://github.com/user-attachments/assets/77c1b9e8-c401-4445-af22-17d74c63dd45" />


Addresses PickNikRobotics/picknik.ai#3377 (item 1).

The **Get Involved** page's *SUBSCRIBE TO OUR NEWSLETTER* button pointed at a Mailchimp list PickNik no longer uses (and is still paying for). Email marketing moved to HubSpot, so this embeds PickNik's HubSpot newsletter form in its place.

## What changed
- **`about/get_involved/index.markdown`** — the Mailchimp `<a>` is replaced by the HubSpot form container (`#newsletter-form`) plus a fallback prompt shown when cookies aren't accepted.
- **`assets/js/consent.js`** — teaches the consent manager about the form:
  - New `loadHubSpotForm()` injects `js.hsforms.net` and creates form `dea35ae4-e2aa-4a2e-9edb-ef5af8a38626` (portal `45692735`) — **only after opt-in**.
  - `hubspotutk`, `__hstc`, `__hssc`, `__hssrc` added to the withdrawal cleanup + reload path.
  - Returning opt-ins load the form on page load; everyone else sees "To subscribe, please accept cookies" until they do.
- **`_sass/_block.scss`** — styles the embedded form to match the site (Inter, blue Subscribe button with hover invert, clean inputs/labels, collapsed hidden UTM wrappers).

## Why gated (not a plain embed)
The HubSpot embed pulls `js.hsforms.net` and sets `hubspotutk`. moveit.ai's consent manager loads every third-party tag only after opt-in, so the form follows the same rule rather than setting a tracking cookie outside the gate.

## Newsletter form fields
The form collects **Email** (required) and **First name** (optional). Email alone would arguably be enough for a newsletter, but the fields are defined on the HubSpot form (`45692735` / `dea35ae4-…`), not in this repo — making it email-only means editing the form in HubSpot. **Left as-is here on purpose**; it can be trimmed in HubSpot later with no code change.

## Verification
Built and viewed the real page locally (GitHub Pages / Jekyll 3.10). Consent gating tested end-to-end against the real `consent.js`:
- Before opt-in: no `js.hsforms.net`, prompt shown.
- On **Accept**: the correct HubSpot form (`hsForm_dea35ae4-…`) renders and the prompt hides; `pn_consent` set.
- On failure (script error / missing `hbspt` / 10s timeout): retry message shown, no empty form area.

Note: this pairs with cancelling the Mailchimp account (tracked separately). Merging this first keeps a working subscribe path before the account goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Replaced the newsletter link with a Subscribe button and embedded form.
* Newsletter content now loads only after visitors choose to subscribe.
* Added consent handling before displaying the form when required.
* Added responsive styling for fields, validation messages, focus states, and submission controls.
* Newsletter preferences continue to support consent acceptance and withdrawal.

## Bug Fixes

* Improved newsletter loading, status, and error handling.
* Prevented unnecessary newsletter content from loading before subscription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
